### PR TITLE
Validate interval is present

### DIFF
--- a/openadr-client/tests/event.rs
+++ b/openadr-client/tests/event.rs
@@ -1,9 +1,10 @@
 use axum::http::StatusCode;
 use openadr_client::{Error, Filter, PaginationOptions};
 use openadr_wire::{
-    event::{EventContent, Priority},
+    event::{EventContent, EventInterval, EventType, EventValuesMap, Priority},
     program::{ProgramContent, ProgramId},
     target::TargetLabel,
+    values_map::Value,
 };
 use sqlx::PgPool;
 
@@ -17,7 +18,14 @@ fn default_content(program_id: &ProgramId) -> EventContent {
         priority: Priority::MAX,
         report_descriptors: None,
         interval_period: None,
-        intervals: vec![],
+        intervals: vec![EventInterval {
+            id: 0,
+            interval_period: None,
+            payloads: vec![EventValuesMap {
+                value_type: EventType::Price,
+                values: vec![Value::Number(123.4)],
+            }],
+        }],
         payload_descriptors: None,
         targets: None,
     }

--- a/openadr-vtn/src/api/event.rs
+++ b/openadr-vtn/src/api/event.rs
@@ -129,8 +129,9 @@ mod test {
     };
     use http_body_util::BodyExt;
     use openadr_wire::{
-        event::{EventPayloadDescriptor, EventType, Priority},
+        event::{EventInterval, EventPayloadDescriptor, EventType, EventValuesMap, Priority},
         problem::Problem,
+        values_map::Value,
     };
     use reqwest::Method;
     use sqlx::PgPool;
@@ -144,13 +145,20 @@ mod test {
             priority: Priority::MAX,
             report_descriptors: None,
             interval_period: None,
-            intervals: vec![],
+            intervals: vec![EventInterval {
+                id: 0,
+                interval_period: None,
+                payloads: vec![EventValuesMap {
+                    value_type: EventType::Price,
+                    values: vec![Value::Number(123.4)],
+                }],
+            }],
             payload_descriptors: None,
             targets: None,
         }
     }
 
-    fn event_request(method: http::Method, event: Event, token: &str) -> Request<Body> {
+    fn event_request(method: Method, event: Event, token: &str) -> Request<Body> {
         Request::builder()
             .method(method)
             .uri(format!("/events/{}", event.id))

--- a/openadr-wire/src/event.rs
+++ b/openadr-wire/src/event.rs
@@ -54,6 +54,7 @@ pub struct EventContent {
     /// Defines default start and durations of intervals.
     pub interval_period: Option<IntervalPeriod>,
     /// A list of interval objects.
+    #[validate(length(min = 1), nested)]
     pub intervals: Vec<EventInterval>,
 }
 
@@ -235,7 +236,7 @@ pub enum Currency {
 /// An object defining a temporal window and a list of valuesMaps. if intervalPeriod present may set
 /// temporal aspects of interval or override event.intervalPeriod.
 #[skip_serializing_none]
-#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Default, Serialize, Deserialize, Validate)]
 #[serde(rename_all = "camelCase")]
 pub struct EventInterval {
     /// A client generated number assigned an interval object. Not a sequence number.
@@ -243,6 +244,7 @@ pub struct EventInterval {
     /// Defines default start and durations of intervals.
     pub interval_period: Option<IntervalPeriod>,
     /// A list of valuesMap objects.
+    #[validate(length(min = 1))]
     pub payloads: Vec<EventValuesMap>,
 }
 

--- a/openadr-wire/src/interval.rs
+++ b/openadr-wire/src/interval.rs
@@ -3,6 +3,7 @@
 use crate::{values_map::ValuesMap, Duration};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 
 /// An object defining a temporal window and a list of valuesMaps. if intervalPeriod present may set
 /// temporal aspects of interval or override event.intervalPeriod.
@@ -30,6 +31,7 @@ impl Interval {
 
 /// Defines temporal aspects of intervals. A duration of default null indicates infinity. A
 /// randomizeStart of default null indicates no randomization.
+#[skip_serializing_none]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IntervalPeriod {
@@ -37,10 +39,8 @@ pub struct IntervalPeriod {
     #[serde(with = "crate::serde_rfc3339")]
     pub start: DateTime<Utc>,
     /// The duration of an interval or set of intervals.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub duration: Option<Duration>,
     /// Indicates a randomization time that may be applied to start.
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub randomize_start: Option<Duration>,
 }
 


### PR DESCRIPTION
Section 7.3 of the v3.0.1 user guide states that:

> Events must include a list of one or more intervals, each of which defines a temporal window, and includes one or more payloads, such as a price value.

This patch enforces that on the server side