### PR TITLE
added health route for deployment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       DATABASE_URL: postgres://openadr:openadr@db:5432/openadr
     healthcheck:
       test: curl --fail http://127.0.0.1:3000/health || exit 1
-      interval: 60s
+      interval: 15s
       timeout: 5s
       retries: 3
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       RUST_LOG: debug
       DATABASE_URL: postgres://openadr:openadr@db:5432/openadr
     healthcheck:
-      test: curl --fail http://127.0.0.1:3000/programs || exit 1
+      test: curl --fail http://127.0.0.1:3000/health || exit 1
       interval: 60s
       timeout: 5s
       retries: 3

--- a/openadr-vtn/src/data_source/mod.rs
+++ b/openadr-vtn/src/data_source/mod.rs
@@ -248,6 +248,7 @@ pub trait DataSource: Send + Sync + 'static {
     fn vens(&self) -> Arc<dyn VenCrud>;
     fn resources(&self) -> Arc<dyn ResourceCrud>;
     fn auth(&self) -> Arc<dyn AuthSource>;
+    fn connection_active(&self) -> bool;
 }
 
 #[derive(Debug, Clone)]

--- a/openadr-vtn/src/data_source/postgres/mod.rs
+++ b/openadr-vtn/src/data_source/postgres/mod.rs
@@ -54,7 +54,7 @@ impl DataSource for PostgresStorage {
         Arc::<PgAuthSource>::new(self.db.clone().into())
     }
 
-    ///Verify the connection pool is open and has at least one connection
+    /// Verify the connection pool is open and has at least one connection
     fn connection_active(&self) -> bool {
         !self.db.is_closed() && self.db.size() > 0
     }

--- a/openadr-vtn/src/data_source/postgres/mod.rs
+++ b/openadr-vtn/src/data_source/postgres/mod.rs
@@ -53,6 +53,11 @@ impl DataSource for PostgresStorage {
     fn auth(&self) -> Arc<dyn AuthSource> {
         Arc::<PgAuthSource>::new(self.db.clone().into())
     }
+
+    ///Verify the connection pool is open and has at least one connection
+    fn connection_active(&self) -> bool {
+        !self.db.is_closed() && self.db.size() > 0
+    }
 }
 
 impl PostgresStorage {

--- a/openadr-vtn/src/error.rs
+++ b/openadr-vtn/src/error.rs
@@ -42,8 +42,8 @@ pub enum AppError {
     #[cfg(feature = "sqlx")]
     #[error("database error: {0}")]
     Sql(sqlx::Error),
-    #[error("Sql connection pool closed")]
-    SqlConnectionPoolClosed,
+    #[error("Storage connection pool closed")]
+    StorageConnectionError,
     #[cfg(feature = "sqlx")]
     #[error("Json (de)serialization error : {0}")]
     SerdeJsonInternalServerError(serde_json::Error),
@@ -246,13 +246,13 @@ impl AppError {
                     instance: Some(reference.to_string()),
                 }
             }
-            AppError::SqlConnectionPoolClosed => {
-                error!(%reference, "Sql connection pool closed");
+            AppError::StorageConnectionError => {
+                error!(%reference, "Storage connection pool closed");
                 Problem {
                     r#type: Default::default(),
                     title: Some(StatusCode::INTERNAL_SERVER_ERROR.to_string()),
                     status: StatusCode::INTERNAL_SERVER_ERROR,
-                    detail: Some("Sql connection pool closed".to_string()),
+                    detail: Some("Storage connection pool closed".to_string()),
                     instance: Some(reference.to_string()),
                 }
             }

--- a/openadr-vtn/src/error.rs
+++ b/openadr-vtn/src/error.rs
@@ -40,8 +40,10 @@ pub enum AppError {
     #[error("Authentication error: {0}")]
     Auth(String),
     #[cfg(feature = "sqlx")]
-    #[error("Database error: {0}")]
+    #[error("database error: {0}")]
     Sql(sqlx::Error),
+    #[error("Sql connection pool closed")]
+    SqlConnectionPoolClosed,
     #[cfg(feature = "sqlx")]
     #[error("Json (de)serialization error : {0}")]
     SerdeJsonInternalServerError(serde_json::Error),
@@ -241,6 +243,16 @@ impl AppError {
                     title: Some(StatusCode::INTERNAL_SERVER_ERROR.to_string()),
                     status: StatusCode::INTERNAL_SERVER_ERROR,
                     detail: Some("A database error occurred".to_string()),
+                    instance: Some(reference.to_string()),
+                }
+            }
+            AppError::SqlConnectionPoolClosed => {
+                error!(%reference, "Sql connection pool closed");
+                Problem {
+                    r#type: Default::default(),
+                    title: Some(StatusCode::INTERNAL_SERVER_ERROR.to_string()),
+                    status: StatusCode::INTERNAL_SERVER_ERROR,
+                    detail: Some("Sql connection pool closed".to_string()),
                     instance: Some(reference.to_string()),
                 }
             }

--- a/openadr-vtn/src/state.rs
+++ b/openadr-vtn/src/state.rs
@@ -1,5 +1,5 @@
 use crate::{
-    api::{auth, event, program, report, resource, user, ven},
+    api::{auth, event, healthcheck, program, report, resource, user, ven},
     data_source::{
         AuthSource, DataSource, EventCrud, ProgramCrud, ReportCrud, ResourceCrud, VenCrud,
     },
@@ -56,6 +56,7 @@ impl AppState {
 
     fn router_without_state() -> axum::Router<Self> {
         axum::Router::new()
+            .route("/health", get(healthcheck))
             .route("/programs", get(program::get_all).post(program::add))
             .route(
                 "/programs/:id",

--- a/vtn.Dockerfile
+++ b/vtn.Dockerfile
@@ -7,20 +7,21 @@ ADD . /app
 WORKDIR /app
 COPY . .
 
-#Don't depend on live sqlx during build use cached .sqlx
+# Don't depend on live sqlx during build use cached .sqlx
 RUN SQLX_OFFLINE=true cargo build --release --bin openadr-vtn
 RUN cp /app/target/release/openadr-vtn /app/openadr-vtn
 
 FROM debian:bookworm-slim as final
+RUN apt-get update && apt-get install curl -y
 
-#create a non root user to run the binary
+# create a non root user to run the binary
 ARG user=nonroot
 ARG group=nonroot
 ARG uid=2000
 ARG gid=2000
 RUN addgroup --gid ${gid} ${group} && adduser --uid ${uid} --gid ${gid} --system --disabled-login --disabled-password ${user}
 EXPOSE 3000
-#get the pre-built binary from builder so that we don't have to re-build every time
+# get the pre-built binary from builder so that we don't have to re-build every time
 COPY --from=1 --chown=nonroot:nonroot /app/openadr-vtn/openadr-vtn /home/nonroot/openadr-vtn
 RUN chmod 777 /home/nonroot/openadr-vtn
 


### PR DESCRIPTION
This PR adds GET /health route for dockerized deployments. 

The route will return an internal server error if DB connection pool is not active. In order to make that work I had to adjust the `DataSource` trait to include a new method `connection_active`. This then allows access to limited details about the PG pool via AppState. 

I also added an error variant for PG pool connection issues which may be useful elsewhere. Looking through the `into_problem` function it feels like that needs to be dried up with a declarative macro that iterates all variants of the enum and uses an attribute on the enum variant to set the message string. But that will be an issue for another PR

The only other notable change on this PR was that the request helper was panicking on the new health route since there was no body to parse. I created another helper to accept requests without a body. 