### PR TITLE
Support currencies in openleadr-wire (#54)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,6 +1135,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "iso_country"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20633e788d3948ea7336861fdb09ec247f5dae4267e8f0743fa97de26c28624d"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "iso_currency"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f402cc74ed2fec6f6fed285d45645a8c7c82e1d1fa694898864ef7c0cb047785"
+dependencies = [
+ "iso_country",
+ "proc-macro2",
+ "quote",
+ "serde",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +1458,7 @@ dependencies = [
  "chrono",
  "http",
  "iso8601-duration",
+ "iso_currency",
  "quickcheck",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,4 @@ argon2 = "0.5.3"
 dotenvy = "0.15.7"
 
 serial_test = "3.1.1"
+

--- a/openleadr-wire/Cargo.toml
+++ b/openleadr-wire/Cargo.toml
@@ -19,6 +19,7 @@ iso8601-duration.workspace = true
 thiserror.workspace = true
 http.workspace = true
 validator.workspace = true
+iso_currency = { version = "0.5.0", features = ["with-serde"] }
 
 [dev-dependencies]
 serde_json.workspace = true

--- a/openleadr-wire/src/event.rs
+++ b/openleadr-wire/src/event.rs
@@ -5,6 +5,7 @@ use crate::{
     values_map::Value, Identifier, IdentifierError, Unit,
 };
 use chrono::{DateTime, Utc};
+use iso_currency::Currency;
 use serde::{Deserialize, Serialize};
 use serde_with::skip_serializing_none;
 use std::{
@@ -206,13 +207,6 @@ impl EventPayloadDescriptor {
             currency: None,
         }
     }
-}
-
-// TODO: Find a nice ISO 4217 crate
-/// A currency described as listed in ISO 4217
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum Currency {
-    Todo,
 }
 
 /// An object defining a temporal window and a list of valuesMaps. if intervalPeriod present may set
@@ -426,6 +420,37 @@ mod tests {
         assert_eq!(
             serde_json::from_str::<Vec<Event>>(example).unwrap()[0],
             expected
+        );
+    }
+
+    #[test]
+    fn test_currency() {
+        // deserialize
+        let example = r#"{"payloadType":"SIMPLE","currency":"EUR"}"#;
+
+        let expected = EventPayloadDescriptor {
+            payload_type: EventType::Simple,
+            units: None,
+            currency: Some(Currency::EUR),
+        };
+
+        assert_eq!(
+            serde_json::from_str::<EventPayloadDescriptor>(&example).unwrap(),
+            expected
+        );
+
+        // round-trip
+        let source = EventPayloadDescriptor {
+            payload_type: EventType::Price,
+            units: Some(Unit::Volts),
+            currency: Some(Currency::USD),
+        };
+
+        let serialized = serde_json::to_string(&source).unwrap();
+
+        assert_eq!(
+            source,
+            serde_json::from_str::<EventPayloadDescriptor>(&serialized).unwrap()
         );
     }
 }


### PR DESCRIPTION
Hi! This addresses #54.

In the issue it's left open whether to add currency support via a crate or by manually maintaining the list of current currencies listed [here](https://www.six-group.com/en/products-services/financial-information/data-standards.html). The [iso_currency](https://crates.io/crates/iso_currency) crate seems popular (65k recent downloads) and maintained (last updated three months ago), and easy enough to integrate, so I opted to use it. I'd be happy to copy/paste the enum from that crate if you'd rather maintain it manually.

Also added a couple simple tests demonstrating serde for the currency field in `EventPayloadDesciptor`.