### PR TITLE
Several improvements to the client

### DIFF
--- a/openleadr-client/src/bin/cli.rs
+++ b/openleadr-client/src/bin/cli.rs
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // let created_event = program
     //     .create_event(program.new_event().with_event_name("prices3").with_priority(0))
     //     .await?;
-    // let events = program.get_event_list(Filter::None).await?;
+    // let events = program.get_event_list(Filter::none()).await?;
     // let reports = events[0].get_all_reports().await?;
     // let event = program.get_event(Target::Event("prices3")).await?;
     // dbg!(events);

--- a/openleadr-client/src/bin/everest.rs
+++ b/openleadr-client/src/bin/everest.rs
@@ -4,7 +4,7 @@ use openleadr_wire::{
     values_map::Value,
 };
 
-use openleadr_client::{ProgramClient, Timeline};
+use openleadr_client::{Filter, ProgramClient, Timeline};
 use std::{error::Error, time::Duration};
 use tokio::{
     select,
@@ -66,14 +66,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 
 async fn poll_timeline(
-    mut program: ProgramClient,
+    program: ProgramClient,
     poll_interval: Duration,
     sender: Sender<Timeline>,
 ) -> Result<(), openleadr_client::Error> {
     loop {
         tokio::time::sleep(poll_interval).await;
 
-        let timeline = program.get_timeline().await?;
+        let timeline = program.get_timeline(Filter::none()).await?;
 
         let Ok(_) = sender.send(timeline).await else {
             return Ok(());

--- a/openleadr-client/src/event.rs
+++ b/openleadr-client/src/event.rs
@@ -17,7 +17,7 @@ use openleadr_wire::{event::EventContent, report::ReportContent, Event, Report};
 /// let program = client.get_program_by_id(&"program-1".parse().unwrap()).await.unwrap();
 ///
 /// // retrieve all events in that specific program
-/// let mut events = program.get_event_list(Filter::None).await.unwrap();
+/// let mut events = program.get_event_list(Filter::none()).await.unwrap();
 /// let mut event = events.remove(0);
 ///
 /// // Set event priority to maximum
@@ -25,7 +25,7 @@ use openleadr_wire::{event::EventContent, report::ReportContent, Event, Report};
 /// event.update().await.unwrap()
 /// # })
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct EventClient {
     client: Arc<ClientRef>,
     data: Event,

--- a/openleadr-client/src/report.rs
+++ b/openleadr-client/src/report.rs
@@ -23,7 +23,7 @@ use crate::{error::Result, ClientRef};
 /// report.update().await.unwrap()
 /// # })
 /// ```
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ReportClient {
     client: Arc<ClientRef>,
     data: Report,

--- a/openleadr-client/src/resource.rs
+++ b/openleadr-client/src/resource.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 /// stored as a child element of a VEN on the VTN.
 ///
 /// To retrieve or create a resource, refer to the [`VenClient`](crate::VenClient).
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ResourceClient {
     client: Arc<ClientRef>,
     ven_id: VenId,

--- a/openleadr-client/src/ven.rs
+++ b/openleadr-client/src/ven.rs
@@ -8,7 +8,7 @@ use openleadr_wire::{
 use std::sync::Arc;
 
 /// A client for interacting with the data in a specific VEN and the resources contained in the VEN.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct VenClient {
     client: Arc<ClientRef>,
     data: Ven,

--- a/openleadr-client/tests/basic-read.rs
+++ b/openleadr-client/tests/basic-read.rs
@@ -12,7 +12,7 @@ async fn basic_create_read(db: PgPool) -> Result<(), openleadr_client::Error> {
         .create_program(ProgramContent::new("test-prog"))
         .await?;
 
-    let programs = client.get_program_list(Filter::None).await?;
+    let programs = client.get_program_list(Filter::none()).await?;
     assert_eq!(programs.len(), 1);
     assert_eq!(programs[0].content().program_name, "test-prog");
 

--- a/openleadr-client/tests/event.rs
+++ b/openleadr-client/tests/event.rs
@@ -63,7 +63,7 @@ async fn delete(db: PgPool) {
 
     let pagination = PaginationOptions { skip: 0, limit: 3 };
     let mut events = client
-        .get_events_request(Filter::None, pagination)
+        .get_events_request(Filter::none(), pagination)
         .await
         .unwrap();
     assert_eq!(events.len(), 3);
@@ -75,7 +75,7 @@ async fn delete(db: PgPool) {
     let removed = event.delete().await.unwrap();
     assert_eq!(removed.content, event2);
 
-    let events = client.get_event_list(Filter::None).await.unwrap();
+    let events = client.get_event_list(Filter::none()).await.unwrap();
     assert_eq!(events.len(), 2);
 }
 
@@ -182,21 +182,21 @@ async fn retrieve_all_with_filter(db: PgPool) {
     }
 
     let events = client
-        .get_events_request(Filter::None, PaginationOptions { skip: 0, limit: 50 })
+        .get_events_request(Filter::none(), PaginationOptions { skip: 0, limit: 50 })
         .await
         .unwrap();
     assert_eq!(events.len(), 3);
 
     // skip
     let events = client
-        .get_events_request(Filter::None, PaginationOptions { skip: 1, limit: 50 })
+        .get_events_request(Filter::none(), PaginationOptions { skip: 1, limit: 50 })
         .await
         .unwrap();
     assert_eq!(events.len(), 2);
 
     // limit
     let events = client
-        .get_events_request(Filter::None, PaginationOptions { skip: 0, limit: 2 })
+        .get_events_request(Filter::none(), PaginationOptions { skip: 0, limit: 2 })
         .await
         .unwrap();
     assert_eq!(events.len(), 2);
@@ -229,7 +229,7 @@ async fn retrieve_all_with_filter(db: PgPool) {
 
     let err = client
         .get_events_request(
-            Filter::By(TargetType::Private("NONSENSE".to_string()), &[]),
+            Filter::<&'static str>::By(TargetType::Private("NONSENSE".to_string()), &[]),
             PaginationOptions { skip: 0, limit: 2 },
         )
         .await
@@ -298,8 +298,8 @@ async fn get_program_events(db: PgPool) {
     program1.create_event(event1.clone()).await.unwrap();
     program2.create_event(event2.clone()).await.unwrap();
 
-    let events1 = program1.get_event_list(Filter::None).await.unwrap();
-    let events2 = program2.get_event_list(Filter::None).await.unwrap();
+    let events1 = program1.get_event_list(Filter::none()).await.unwrap();
+    let events2 = program2.get_event_list(Filter::none()).await.unwrap();
 
     assert_eq!(events1.len(), 1);
     assert_eq!(events2.len(), 1);
@@ -313,7 +313,11 @@ async fn filter_constraint_violation(db: PgPool) {
     let client = common::setup_client(db).await;
 
     let err = client
-        .get_events(None, Filter::None, PaginationOptions { skip: 0, limit: 51 })
+        .get_events(
+            None,
+            Filter::none(),
+            PaginationOptions { skip: 0, limit: 51 },
+        )
         .await
         .unwrap_err();
     let Error::Problem(problem) = err else {
@@ -322,7 +326,11 @@ async fn filter_constraint_violation(db: PgPool) {
     assert_eq!(problem.status, StatusCode::BAD_REQUEST);
 
     let err = client
-        .get_events(None, Filter::None, PaginationOptions { skip: 0, limit: 0 })
+        .get_events(
+            None,
+            Filter::none(),
+            PaginationOptions { skip: 0, limit: 0 },
+        )
         .await
         .unwrap_err();
     let Error::Problem(problem) = err else {

--- a/openleadr-client/tests/program.rs
+++ b/openleadr-client/tests/program.rs
@@ -63,7 +63,7 @@ async fn delete(db: PgPool) {
     let removed = program.delete().await.unwrap();
     assert_eq!(removed.content, program2);
 
-    let programs = client.get_program_list(Filter::None).await.unwrap();
+    let programs = client.get_program_list(Filter::none()).await.unwrap();
     assert_eq!(programs.len(), 2);
 }
 
@@ -173,21 +173,21 @@ async fn retrieve_all_with_filter(db: PgPool) {
     }
 
     let programs = client
-        .get_programs(Filter::None, PaginationOptions { skip: 0, limit: 50 })
+        .get_programs(Filter::none(), PaginationOptions { skip: 0, limit: 50 })
         .await
         .unwrap();
     assert_eq!(programs.len(), 3);
 
     // skip
     let programs = client
-        .get_programs(Filter::None, PaginationOptions { skip: 1, limit: 50 })
+        .get_programs(Filter::none(), PaginationOptions { skip: 1, limit: 50 })
         .await
         .unwrap();
     assert_eq!(programs.len(), 2);
 
     // limit
     let programs = client
-        .get_programs(Filter::None, PaginationOptions { skip: 0, limit: 2 })
+        .get_programs(Filter::none(), PaginationOptions { skip: 0, limit: 2 })
         .await
         .unwrap();
     assert_eq!(programs.len(), 2);
@@ -195,7 +195,7 @@ async fn retrieve_all_with_filter(db: PgPool) {
     // program name
     let err = client
         .get_programs(
-            Filter::By(TargetType::Private("NONSENSE".to_string()), &[]),
+            Filter::<&'static str>::By(TargetType::Private("NONSENSE".to_string()), &[]),
             PaginationOptions { skip: 0, limit: 2 },
         )
         .await

--- a/openleadr-client/tests/ven.rs
+++ b/openleadr-client/tests/ven.rs
@@ -36,7 +36,7 @@ async fn crud() {
 
     // Retrieve all
     {
-        let vens = ctx.get_ven_list(Filter::None).await.unwrap();
+        let vens = ctx.get_ven_list(Filter::none()).await.unwrap();
         assert!(vens.iter().any(|v| v.content().ven_name == "test-ven"));
     }
 


### PR DESCRIPTION
- Filter now takes a slice of `impl AsRef<str>` allowing it to work with a slice of strings among others
- All of the specific clients for programs, events etc are also `Clone` allowing them to be easier to use
- The `ProgramClient::get_timeline` method can take a filter and doesn't need a mutable client anymore