### PR TITLE
Authentication improvements

### DIFF
--- a/openleadr-vtn/README.md
+++ b/openleadr-vtn/README.md
@@ -62,8 +62,7 @@ The OAuth configuration of the VTN is done via the following environment variabl
 - `OAUTH_BASE64_SECRET` (must be at least 256 bit long. Required if `OAUTH_KEY_TYPE` is `HMAC`)
 - `OAUTH_KEY_TYPE`(allows values: `HMAC`, `RSA`, `EC`, `ED`. Defaults to `HMAC`)
 - `OAUTH_PEM` (path to a PEM encoded public key file. Required for all `OAUTH_KEY_TYPE`s, except `HMAC`)
-- `OAUTH_VALID_AUDIENCES` (specifies the list of valid audiences for token validation, ensuring that the token is intended for the correct recipient. Defaults to an empty list, which will
-fail validation if an `aud` claim is present in a decoded access token.)
+- `OAUTH_VALID_AUDIENCES` (specifies the list of valid audiences for token validation, ensuring that the token is intended for the correct recipient. Required when `OAUTH_TYPE` is `EXTERNAL`. Optional and defaults to an empty list when `OAUTH_TYPE` is `INTERNAL`, which will fail validation if an `aud` claim is present in the decoded access token.)
 
 The internal OAuth provider does only support `HMAC`.
 

--- a/openleadr-vtn/README.md
+++ b/openleadr-vtn/README.md
@@ -62,6 +62,8 @@ The OAuth configuration of the VTN is done via the following environment variabl
 - `OAUTH_BASE64_SECRET` (must be at least 256 bit long. Required if `OAUTH_KEY_TYPE` is `HMAC`)
 - `OAUTH_KEY_TYPE`(allows values: `HMAC`, `RSA`, `EC`, `ED`. Defaults to `HMAC`)
 - `OAUTH_PEM` (path to a PEM encoded public key file. Required for all `OAUTH_KEY_TYPE`s, except `HMAC`)
+- `OAUTH_VALID_AUDIENCES` (specifies the list of valid audiences for token validation, ensuring that the token is intended for the correct recipient. Defaults to an empty list, which will
+fail validation if an `aud` claim is present in a decoded access token.)
 
 The internal OAuth provider does only support `HMAC`.
 

--- a/openleadr-vtn/src/jwt.rs
+++ b/openleadr-vtn/src/jwt.rs
@@ -24,7 +24,7 @@ pub struct JwtManager {
     #[cfg(feature = "internal-oauth")]
     encoding_key: Option<EncodingKey>,
     decoding_key: DecodingKey,
-    validation: Validation
+    validation: Validation,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -147,7 +147,11 @@ impl Claims {
 
 impl JwtManager {
     /// Create a new JWT manager with a specific encoding and decoding key
-    pub fn new(encoding_key: Option<EncodingKey>, decoding_key: DecodingKey, validation: Validation) -> Self {
+    pub fn new(
+        encoding_key: Option<EncodingKey>,
+        decoding_key: DecodingKey,
+        validation: Validation,
+    ) -> Self {
         if !cfg!(feature = "internal-oauth") && encoding_key.is_some() {
             panic!("You should not provide a JWT encoding key as the 'internal-oauth' feature is disabled. \
             Please recompile with the 'internal-oauth' feature enabled if you want to use it.");
@@ -157,14 +161,14 @@ impl JwtManager {
             Self {
                 encoding_key,
                 decoding_key,
-                validation
+                validation,
             }
         }
         #[cfg(not(feature = "internal-oauth"))]
         {
             Self {
                 decoding_key,
-                validation
+                validation,
             }
         }
     }
@@ -201,7 +205,8 @@ impl JwtManager {
 
     /// Decode and validate a given JWT token, returning the validated claims
     fn decode_and_validate(&self, token: &str) -> Result<Claims, jsonwebtoken::errors::Error> {
-        let token_data = jsonwebtoken::decode::<Claims>(token, &self.decoding_key, &self.validation)?;
+        let token_data =
+            jsonwebtoken::decode::<Claims>(token, &self.decoding_key, &self.validation)?;
         Ok(token_data.claims)
     }
 }

--- a/openleadr-vtn/src/jwt.rs
+++ b/openleadr-vtn/src/jwt.rs
@@ -16,7 +16,7 @@ use axum_extra::{
     headers::{authorization::Bearer, Authorization},
     TypedHeader,
 };
-use jsonwebtoken::{DecodingKey, EncodingKey};
+use jsonwebtoken::{DecodingKey, EncodingKey, Validation};
 use openleadr_wire::ven::VenId;
 use tracing::trace;
 
@@ -24,6 +24,7 @@ pub struct JwtManager {
     #[cfg(feature = "internal-oauth")]
     encoding_key: Option<EncodingKey>,
     decoding_key: DecodingKey,
+    validation: Validation
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -146,7 +147,7 @@ impl Claims {
 
 impl JwtManager {
     /// Create a new JWT manager with a specific encoding and decoding key
-    pub fn new(encoding_key: Option<EncodingKey>, decoding_key: DecodingKey) -> Self {
+    pub fn new(encoding_key: Option<EncodingKey>, decoding_key: DecodingKey, validation: Validation) -> Self {
         if !cfg!(feature = "internal-oauth") && encoding_key.is_some() {
             panic!("You should not provide a JWT encoding key as the 'internal-oauth' feature is disabled. \
             Please recompile with the 'internal-oauth' feature enabled if you want to use it.");
@@ -156,11 +157,15 @@ impl JwtManager {
             Self {
                 encoding_key,
                 decoding_key,
+                validation
             }
         }
         #[cfg(not(feature = "internal-oauth"))]
         {
-            Self { decoding_key }
+            Self {
+                decoding_key,
+                validation
+            }
         }
     }
 
@@ -196,8 +201,7 @@ impl JwtManager {
 
     /// Decode and validate a given JWT token, returning the validated claims
     fn decode_and_validate(&self, token: &str) -> Result<Claims, jsonwebtoken::errors::Error> {
-        let validation = jsonwebtoken::Validation::default();
-        let token_data = jsonwebtoken::decode::<Claims>(token, &self.decoding_key, &validation)?;
+        let token_data = jsonwebtoken::decode::<Claims>(token, &self.decoding_key, &self.validation)?;
         Ok(token_data.claims)
     }
 }

--- a/openleadr-vtn/src/state.rs
+++ b/openleadr-vtn/src/state.rs
@@ -79,7 +79,7 @@ impl FromStr for OAuthKeyType {
 fn audiences_from_env() -> Result<Vec<String>, VarError> {
     env::var("OAUTH_VALID_AUDIENCES").map(|audience_str| {
         // Split the string by commas and collect into a vector
-        return audience_str.split(',').map(|s| s.to_string()).collect();
+        audience_str.split(',').map(|s| s.to_string()).collect();
     })
 }
 
@@ -142,7 +142,7 @@ fn internal_oauth_from_env(key_type: Option<OAuthKeyType>) -> JwtManager {
 
     let mut validation = Validation::default();
     validation.algorithms =
-        signing_algorithms_from_key_type(&key_type.unwrap_or_else(|| OAuthKeyType::Hmac));
+        signing_algorithms_from_key_type(&key_type.unwrap_or(OAuthKeyType::Hmac));
     validation.set_audience(&valid_audiences);
 
     JwtManager::new(

--- a/openleadr-vtn/src/state.rs
+++ b/openleadr-vtn/src/state.rs
@@ -79,7 +79,7 @@ impl FromStr for OAuthKeyType {
 fn audiences_from_env() -> Result<Vec<String>, VarError> {
     env::var("OAUTH_VALID_AUDIENCES").map(|audience_str| {
         // Split the string by commas and collect into a vector
-        audience_str.split(',').map(|s| s.to_string()).collect();
+        audience_str.split(',').map(|s| s.to_string()).collect()
     })
 }
 
@@ -156,7 +156,7 @@ fn external_oauth_from_env(key_type: Option<OAuthKeyType>) -> JwtManager {
     let key_type = key_type.expect("Must specify key type for external OAuth provider. Use OAUTH_KEY_TYPE environment variable");
 
     let valid_audiences = audiences_from_env().expect(
-        "OAUTH_VALID_AUDIENCES environment variable must be set for external Oauth provider.",
+        "OAUTH_VALID_AUDIENCES environment variable must be set for external Oauth provider",
     );
 
     let mut validation = Validation::default();
@@ -390,6 +390,7 @@ mod test {
             env::remove_var("OAUTH_TYPE");
             env::remove_var("OAUTH_KEY_TYPE");
             env::remove_var("OAUTH_PEM");
+            env::remove_var("OAUTH_VALID_AUDIENCES");
         }
 
         #[test]
@@ -468,6 +469,7 @@ mod test {
         fn external_missing_key_type_oauth() {
             clean_env();
             env::set_var("OAUTH_TYPE", "EXTERNAL");
+            env::set_var("OAUTH_VALID_AUDIENCES", "http://localhost:3000,");
             env::set_var("OAUTH_PEM", "./key.pem");
             AppState::new(MockDataSource {});
         }
@@ -480,7 +482,21 @@ mod test {
         fn external_missing_key_oauth() {
             clean_env();
             env::set_var("OAUTH_TYPE", "EXTERNAL");
+            env::set_var("OAUTH_VALID_AUDIENCES", "http://localhost:3000,");
             env::set_var("OAUTH_KEY_TYPE", "RSA");
+            AppState::new(MockDataSource {});
+        }
+
+        #[test]
+        #[should_panic(
+            expected = "OAUTH_VALID_AUDIENCES environment variable must be set for external Oauth provider"
+        )]
+        #[serial]
+        fn external_missing_valid_audiences_oauth() {
+            clean_env();
+            env::set_var("OAUTH_TYPE", "EXTERNAL");
+            env::set_var("OAUTH_KEY_TYPE", "RSA");
+            env::set_var("OAUTH_PEM", "./tests/assets/public-rsa.pem");
             AppState::new(MockDataSource {});
         }
 
@@ -491,6 +507,7 @@ mod test {
             env::set_var("OAUTH_TYPE", "EXTERNAL");
             env::set_var("OAUTH_KEY_TYPE", "RSA");
             env::set_var("OAUTH_PEM", "./tests/assets/public-rsa.pem");
+            env::set_var("OAUTH_VALID_AUDIENCES", "http://localhost:3000,");
             AppState::new(MockDataSource {});
         }
 
@@ -501,6 +518,7 @@ mod test {
             clean_env();
             env::set_var("OAUTH_TYPE", "EXTERNAL");
             env::set_var("OAUTH_KEY_TYPE", "EC");
+            env::set_var("OAUTH_VALID_AUDIENCES", "http://localhost:3000,");
             env::set_var("OAUTH_PEM", "./tests/assets/public-rsa.pem");
             AppState::new(MockDataSource {});
         }
@@ -512,6 +530,7 @@ mod test {
             clean_env();
             env::set_var("OAUTH_TYPE", "EXTERNAL");
             env::set_var("OAUTH_KEY_TYPE", "ED");
+            env::set_var("OAUTH_VALID_AUDIENCES", "http://localhost:3000,");
             env::set_var("OAUTH_PEM", "./tests/assets/public-rsa.pem");
             AppState::new(MockDataSource {});
         }


### PR DESCRIPTION
This PR fixes issue mentioned in #185, where the token decoding only works when the JWT token is signed with HS256.

Additionally, I noticed that the audience validation will raise an InvalidAudience when an `aud` claim is present in the token (which is standard for many OAUTH providers), even though [`aud`](https://github.com/Keats/jsonwebtoken/blob/master/src/validation.rs#L83C9-L83C12) is set to None inside jsonwebtoken::validation by default.

This previously worked without issues for the internal authentication as it did not include the `aud` claim in the provisioned access token. I've added an additional environment variable called `OAUTH_VALID_AUDIENCES` which contains a comma seperated list of audiences that are considered valid for the VTN.