### PR TITLE
enable tls backend for sqlx, improve dockerfile for azure app service compatability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,6 +2370,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -2379,6 +2380,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3101,6 +3103,24 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.1",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8782dd5a41a24eed3a4f40b606249b3e236ca61adf1f25ea4d45c73de122b502"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ async-trait = "0.1.81"
 
 quickcheck = "1.0.3"
 
-sqlx = { version = "0.8.2", features = ["postgres", "runtime-tokio", "chrono", "migrate", "macros", "json"], default-features = false }
+sqlx = { version = "0.8.2", features = ["postgres", "runtime-tokio", "chrono", "migrate", "macros", "json", "tls-rustls"], default-features = false }
 argon2 = "0.5.3"
 dotenvy = "0.15.7"
 

--- a/deny.toml
+++ b/deny.toml
@@ -16,7 +16,8 @@ allow = [
     "BSD-3-Clause",
     "ISC",
     "OpenSSL",
-    "Zlib"
+    "Zlib",
+    "CDLA-Permissive-2.0"
 ]
 
 [[licenses.clarify]]

--- a/vtn.Dockerfile
+++ b/vtn.Dockerfile
@@ -28,10 +28,12 @@ RUN addgroup -g ${gid} ${group} && \
 
 EXPOSE 3000
 
+WORKDIR /dist
+
 # get the pre-built binary from builder so that we don't have to re-build every time
-COPY --from=1 --chown=nonroot:nonroot /app/openleadr-vtn/openleadr-vtn /home/nonroot/openleadr-vtn
-RUN chmod 777 /home/nonroot/openleadr-vtn
+COPY --from=builder --chown=nonroot:nonroot /app/openleadr-vtn/openleadr-vtn /dist/openleadr-vtn
+RUN chmod 777 /dist/openleadr-vtn
 
 USER $user
 
-ENTRYPOINT ["./home/nonroot/openleadr-vtn"]
+ENTRYPOINT ["/dist/openleadr-vtn"]


### PR DESCRIPTION
Hi! This PR contains some (minor) changes I made in a fork of openleadr while deploying the VTN package to a pilot environment.

I hope these changes are all fine, if not, let me know, and I can make the necessary changes.

## Changes

### Sqlx TLS Backend

I've added the `tls-rustls` feature to the `sqlx` package so it can connect to a database which enforces TLS (i've only had the chance to test this with an Azure Postgres Server).


### Dockerfile change for compatibility with Azure

I ran into a weird issue while deploying the VTN within an Azure App Service where it failed to run the openleadr image because the /home/nonroot folder could not be found. While running the openleadr image on two other devices works without issues.

I tried setting the entrypoint to the absolute path and forcing the creation of the folder by setting the workdir in the dockerfile but this still failed.

I've opted to alter the dockerfile slightly to copy the VTN to a /dist folder and give the nonroot user access to that folder, then it works as expected within an Azure App Service. I have no idea why it didn't work with the home folder, might be some Azure App Service specific mumbo jumbo, if you have any idea, feel free to let me know.