### PR TITLE
Improvement to scope parsing when it is in the 'roles' claim of the JWT token

### DIFF
--- a/openleadr-vtn/src/jwt.rs
+++ b/openleadr-vtn/src/jwt.rs
@@ -123,6 +123,8 @@ pub enum Scope {
     WriteEvents,
     #[serde(rename = "write_vens")]
     WriteVens,
+    #[serde(untagged)]
+    UnknownScope(String),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Deserialize)]


### PR DESCRIPTION
This PR adds an untagged `UnknownScope` case to the Scope enum.

This edge case encapsulates all non-openadr3 role values and prevents serde from throwing if an unknown enum case is detected which does not match with any of the OpenADR3 role claims (such as `read_all`, `write_events`, etc).

This way, the VTN does not needlessly reject a token if it contains all the right roles, but also contains some other role (which might be automatically added by an auth server)