### PR TITLE
Remove NBF claim requirement from jwt token

### DIFF
--- a/openleadr-vtn/src/jwt.rs
+++ b/openleadr-vtn/src/jwt.rs
@@ -179,7 +179,7 @@ struct EdKeys {
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub(crate) struct Claims {
     exp: usize,
-    nbf: usize,
+    nbf: Option<usize>,
     pub(crate) sub: String,
     pub(crate) roles: Vec<AuthRole>,
 }
@@ -187,7 +187,7 @@ pub(crate) struct Claims {
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 struct InitialClaims {
     exp: usize,
-    nbf: usize,
+    nbf: Option<usize>,
     sub: String,
     #[serde(default)]
     // Allow the roles claim to either contain the internal roles structure of OpenLEADR
@@ -333,7 +333,7 @@ impl Claims {
     pub(crate) fn new(roles: Vec<AuthRole>) -> Self {
         Self {
             exp: 0,
-            nbf: 0,
+            nbf: Some(0),
             sub: "".to_string(),
             roles,
         }
@@ -449,7 +449,7 @@ impl JwtManager {
 
         let claims = Claims {
             exp: exp.timestamp() as usize,
-            nbf: now.timestamp() as usize,
+            nbf: Some(now.timestamp() as usize),
             sub: client_id,
             roles,
         };
@@ -711,7 +711,7 @@ mod tests {
     fn test_no_roles_no_scope_into_claims() {
         let initial = InitialClaims {
             exp: 10,
-            nbf: 10,
+            nbf: Some(10),
             sub: "test".to_string(),
             roles: None,
             scope: None,
@@ -725,7 +725,7 @@ mod tests {
     fn test_initial_roles_into_claims() {
         let initial = InitialClaims {
             exp: 10,
-            nbf: 10,
+            nbf: Some(10),
             sub: "test".to_string(),
             roles: Some(RolesOrScopes::AuthRoles(vec![
                 AuthRole::AnyBusiness,
@@ -751,7 +751,7 @@ mod tests {
     fn test_scope_ignored_if_roles_present() {
         let initial = InitialClaims {
             exp: 10,
-            nbf: 10,
+            nbf: Some(10),
             sub: "test".to_string(),
             roles: Some(RolesOrScopes::AuthRoles(vec![AuthRole::AnyBusiness])),
             scope: Some(Scopes {
@@ -770,7 +770,7 @@ mod tests {
     fn test_scope_into_any_business_role() {
         let initial = InitialClaims {
             exp: 10,
-            nbf: 10,
+            nbf: Some(10),
             sub: "test".to_string(),
             roles: None,
             scope: Some(Scopes {
@@ -792,7 +792,7 @@ mod tests {
     fn test_scope_into_ven_manager_role() {
         let initial = InitialClaims {
             exp: 10,
-            nbf: 10,
+            nbf: Some(10),
             sub: "test".to_string(),
             roles: None,
             scope: Some(Scopes {
@@ -814,7 +814,7 @@ mod tests {
     fn test_scope_into_anonymous_ven_role() {
         let initial = InitialClaims {
             exp: 10,
-            nbf: 10,
+            nbf: Some(10),
             sub: "test".to_string(),
             roles: None,
             scope: Some(Scopes {
@@ -839,7 +839,7 @@ mod tests {
     fn test_scope_into_multiple_roles() {
         let initial = InitialClaims {
             exp: 10,
-            nbf: 10,
+            nbf: Some(10),
             sub: "test".to_string(),
             roles: None,
             scope: Some(Scopes {
@@ -869,7 +869,7 @@ mod tests {
     fn test_oadr_roles_into_any_business_role() {
         let initial = InitialClaims {
             exp: 10,
-            nbf: 10,
+            nbf: Some(10),
             sub: "test".to_string(),
             roles: Some(RolesOrScopes::Scopes(vec![
                 Scope::ReadAll,
@@ -893,7 +893,7 @@ mod tests {
     fn test_oadr_roles_into_ven_manager_role() {
         let initial = InitialClaims {
             exp: 10,
-            nbf: 10,
+            nbf: Some(10),
             sub: "test".to_string(),
             roles: Some(RolesOrScopes::Scopes(vec![
                 Scope::ReadAll,
@@ -916,7 +916,7 @@ mod tests {
     fn test_oadr_roles_into_anonymous_ven_role() {
         let initial = InitialClaims {
             exp: 10,
-            nbf: 10,
+            nbf: Some(10),
             sub: "test".to_string(),
             roles: Some(RolesOrScopes::Scopes(vec![
                 Scope::ReadAll,

--- a/openleadr-vtn/src/state.rs
+++ b/openleadr-vtn/src/state.rs
@@ -151,6 +151,7 @@ fn internal_oauth_from_env(key_type: Option<OAuthKeyType>) -> JwtManager {
     });
 
     let mut validation = Validation::default();
+    validation.validate_nbf = true;
     validation.algorithms =
         signing_algorithms_from_key_type(&key_type.unwrap_or(OAuthKeyType::Hmac));
     validation.set_audience(&valid_audiences);
@@ -172,6 +173,7 @@ async fn external_oauth_from_env(key_type: Option<OAuthKeyType>) -> JwtManager {
     let mut validation = Validation::default();
     validation.algorithms = signing_algorithms_from_key_type(&key_type);
     validation.set_audience(&valid_audiences);
+    validation.validate_nbf = true;
 
     let oauth_jwks_location = env::var("OAUTH_JWKS_LOCATION");
     let oauth_keyfile = env::var("OAUTH_PEM");


### PR DESCRIPTION
Hi!

This PR makes the `nbf` claim in the JWT token optional, since the [OAUTH2 specification](https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.5) also defines it as optional. If the `nbf` claim is present in a JWT token it will be validated by the `jsonwebtoken` library through the `validation` object.

If the `nbf` claim is not present, validation for the `nbf` claim is skipped as it is an optional claim.