### PR TITLE
Improve Docker version tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,9 +19,14 @@ jobs:
       - name: Create version tag
         shell: bash
         run: echo "tag=ghcr.io/openleadr/openleadr-rs:$(git show -s --format="%ct-%h" $GITHUB_SHA)" >> $GITHUB_ENV
-      - name: Latest tag on main branch
+      - name: "'main' tag on main branch"
         if: github.ref == 'refs/heads/main'
-        run: echo "tag_main=,ghcr.io/openleadr/openleadr-rs:latest" >> $GITHUB_ENV
+        run: echo "tag=${{ env.tag }},ghcr.io/openleadr/openleadr-rs:main" >> $GITHUB_ENV
+      - name: "explicit release tags & 'latest' tag"
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          REF=${{ github.ref }}
+          echo "tag=${{ env.tag }},ghcr.io/openleadr/openleadr-rs:${REF:11},ghcr.io/openleadr/openleadr-rs:latest" >> $GITHUB_ENV
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -35,7 +40,7 @@ jobs:
         with:
           context: .
           file: ./vtn.Dockerfile
-          tags: "${{ env.tag }}${{ env.tag_main }}"
+          tags: "${{ env.tag }}"
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
From now on, tagging of Docker images will work as follows:
- Every push creates an image with a tag built from the commit timestamp and its hash (`git show -s --format="%ct-%h"`)
- The latest commit on the `main` branch will create an image with a `main` tag
- Every Git version tag will translate to a docker tag
- The latest version tagged in git will be marked `latest` in docker