### PR TITLE
Mark websockets support as experimental and disabled by default 

### DIFF
--- a/openleadr-vtn/Cargo.toml
+++ b/openleadr-vtn/Cargo.toml
@@ -19,7 +19,7 @@ serde.workspace = true
 serde_json.workspace = true
 
 reqwest.workspace = true
-axum = { workspace = true, features = ["ws"] }
+axum.workspace = true
 axum-extra.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tower-http = { workspace = true }
@@ -59,6 +59,7 @@ live-db-test = ["postgres", "internal-oauth"]
 postgres = ["sqlx/postgres", "dep:dotenvy", "dep:argon2"]
 internal-oauth = []
 mdns = ["dep:mdns-sd"]
+experimental-websockets = ["axum/ws"] # object privacy is not yet implemented
 compression-br = ["tower-http/compression-br"]
 compression-deflate = ["tower-http/compression-deflate"]
 compression-gzip = ["tower-http/compression-gzip"]

--- a/openleadr-vtn/src/api/subscription.rs
+++ b/openleadr-vtn/src/api/subscription.rs
@@ -1,11 +1,12 @@
 use std::{collections::HashMap, sync::Arc};
 
+#[cfg(feature = "experimental-websockets")]
 use axum::{
-    extract::{
-        ws::{Message, WebSocketUpgrade},
-        Path, State,
-    },
+    extract::ws::{Message, WebSocketUpgrade},
     response::Response,
+};
+use axum::{
+    extract::{Path, State},
     Json,
 };
 use openleadr_wire::{
@@ -311,9 +312,12 @@ pub(crate) async fn notifier_get(User(user): User) -> Result<Json<NotifiersRespo
         return Err(AppError::Forbidden("Missing 'read_all' scope"));
     }
 
-    Ok(Json(NotifiersResponse { websocket: true }))
+    Ok(Json(NotifiersResponse {
+        websocket: cfg!(feature = "experimental-websockets"),
+    }))
 }
 
+#[cfg(feature = "experimental-websockets")]
 pub(crate) async fn notifier_websocket_get(
     State(notifier_state): State<Arc<NotifierState>>,
     User(user): User,

--- a/openleadr-vtn/src/api/subscription.rs
+++ b/openleadr-vtn/src/api/subscription.rs
@@ -331,6 +331,7 @@ pub(crate) async fn notifier_websocket_get(
 
     let mut websockets = notifier_state.websockets.lock().await;
     if websockets.contains_key(&client_id) {
+        // FIXME close existing connection instead
         return Err(AppError::Conflict(
             "websocket connection already open".to_owned(),
             None,

--- a/openleadr-vtn/src/state.rs
+++ b/openleadr-vtn/src/state.rs
@@ -340,8 +340,11 @@ impl AppState {
                     .delete(subscription::delete),
             )
             .route("/auth/server", get(auth_server_handler))
-            .route("/notifiers", get(subscription::notifier_get))
-            .route("/notifiers/ws", get(subscription::notifier_websocket_get));
+            .route("/notifiers", get(subscription::notifier_get));
+        #[cfg(feature = "experimental-websockets")]
+        {
+            router = router.route("/notifiers/ws", get(subscription::notifier_websocket_get));
+        }
         #[cfg(feature = "internal-oauth")]
         {
             router = router


### PR DESCRIPTION
Object privacy isn't implemented yet for websockets.