### PR TITLE
Ensure aud parsing for JWT tokens supports both vec<string> and single string

### DIFF
--- a/openleadr-vtn/src/jwt.rs
+++ b/openleadr-vtn/src/jwt.rs
@@ -241,7 +241,7 @@ struct EdKeys {
     keys: Vec<EdKey>,
 }
 
-#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
 pub(crate) struct Claims {
     /// (subject): Subject of the JWT (the user)
     pub(crate) sub: String,
@@ -269,7 +269,7 @@ impl Claims {
     }
 }
 
-#[derive(Clone, Debug, serde::Serialize, Default, derive_more::From, AsRef)]
+#[derive(Clone, Debug, serde::Serialize, Default, derive_more::From, AsRef, PartialEq)]
 #[serde(transparent)]
 pub struct Scopes(Vec<Scope>);
 
@@ -620,7 +620,10 @@ where
 
 #[cfg(test)]
 mod test {
-    use crate::{api::test::ApiTest, jwt::Scope};
+    use crate::{
+        api::test::ApiTest,
+        jwt::{Claims, Scope},
+    };
     use axum::{body::Body, http::Method};
     use openleadr_wire::problem::Problem;
     use sqlx::PgPool;
@@ -656,5 +659,66 @@ mod test {
             .await;
         assert_eq!(problem.detail, Some("OAuth2 subject cannot be parsed as OpenADR clientId: identifier contains characters besides [a-zA-Z0-9_-]: This is not a valid client ID".to_string()));
         assert_eq!(status_code, 401);
+    }
+
+    #[test]
+    fn claims_deserializes() {
+        let claim_no_aud = r#"{ "sub": "test-no", "exp": 1}"#;
+        let claim_single_aud_str =
+            r#"{ "sub": "test-single-str", "aud": "single_audience_str", "exp": 2}"#;
+        let claim_single_aud_vec =
+            r#"{ "sub": "test-single-vec", "aud": ["single_audience_vec"], "exp": 3}"#;
+        let claim_multiple_aud =
+            r#"{ "sub": "test-multiple", "aud": ["audience_1", "audience_2"], "exp": 4}"#;
+
+        let claim_no_aud = serde_json::from_str::<Claims>(claim_no_aud).unwrap();
+        let claim_single_aud_vec = serde_json::from_str::<Claims>(claim_single_aud_vec).unwrap();
+        let claim_single_aud_str = serde_json::from_str::<Claims>(claim_single_aud_str).unwrap();
+        let claim_multiple_aud = serde_json::from_str::<Claims>(claim_multiple_aud).unwrap();
+
+        assert_eq!(
+            claim_no_aud,
+            Claims {
+                sub: "test-no".to_string(),
+                aud: None,
+                exp: 1,
+                iat: None,
+                nbf: None,
+                scope: crate::jwt::Scopes(Vec::with_capacity(0))
+            }
+        );
+        assert_eq!(
+            claim_single_aud_str,
+            Claims {
+                sub: "test-single-str".to_string(),
+                aud: Some(vec!["single_audience_str".to_string()]),
+                exp: 2,
+                iat: None,
+                nbf: None,
+                scope: crate::jwt::Scopes(Vec::with_capacity(0))
+            }
+        );
+        assert_eq!(
+            claim_single_aud_vec,
+            Claims {
+                sub: "test-single-vec".to_string(),
+                aud: Some(vec!["single_audience_vec".to_string()]),
+                exp: 3,
+                iat: None,
+                nbf: None,
+                scope: crate::jwt::Scopes(Vec::with_capacity(0))
+            }
+        );
+        assert_eq!(
+            claim_multiple_aud,
+            Claims {
+                sub: "test-multiple".to_string(),
+                aud: Some(vec!["audience_1".to_string(), "audience_2".to_string(),]),
+                exp: 4,
+                iat: None,
+                nbf: None,
+                scope: crate::jwt::Scopes(Vec::with_capacity(0))
+            }
+        );
     }
 }

--- a/openleadr-vtn/src/jwt.rs
+++ b/openleadr-vtn/src/jwt.rs
@@ -92,6 +92,62 @@ where
     Ok(result)
 }
 
+/// Deserializes the JWT `aud` claim which can be either a single string or an array of strings.
+/// Always returns `Option<Vec<String>>` internally.
+mod string_or_vec {
+    use serde::{de, Deserializer};
+    use std::fmt;
+
+    struct StringOrVecVisitor;
+
+    impl<'de> de::Visitor<'de> for StringOrVecVisitor {
+        type Value = Option<Vec<String>>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a string or an array of strings")
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_unit<E>(self) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(None)
+        }
+
+        fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(Some(vec![s.to_owned()]))
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::SeqAccess<'de>,
+        {
+            let mut result = Vec::new();
+            while let Some(item) = seq.next_element::<String>()? {
+                result.push(item);
+            }
+            Ok(Some(result))
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(StringOrVecVisitor)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, sqlx::Type)]
 #[sqlx(type_name = "scope", rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
@@ -195,7 +251,9 @@ pub(crate) struct Claims {
     iat: Option<i64>,
     /// (not before time): Time before which the JWT must not be accepted for processing
     nbf: Option<i64>,
-    /// (audience): Recipient the JWT is intended for (the VTN)
+    /// (audience): Recipient the JWT is intended for (the VTN).
+    /// Can be a single string or an array of strings in the JWT, always deserialized as Vec.
+    #[serde(default, deserialize_with = "string_or_vec::deserialize")]
     aud: Option<Vec<String>>,
     #[serde(default, alias = "roles")]
     pub(crate) scope: Scopes,


### PR DESCRIPTION
Noticed while testing the latest version of OpenLEADR.

As stated in the RFC for the audience claim: https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3

it can be both a list of strings and a single string, in the case of Microsoft Entra, when a single audience is present, it is a single string, which causes validation to fail due to a parsing error.

This PR resolves this issue by allowing both a single string and a vec<string> as audience parameter.

As always, I'm no rust expert, so feel free to tweak the code as needed. 
