### PR TITLE
Allow ven clients to delete their own vens.

### DIFF
--- a/openleadr-vtn/src/api/ven.rs
+++ b/openleadr-vtn/src/api/ven.rs
@@ -178,6 +178,8 @@ pub async fn delete(
 ) -> AppResponse<Ven> {
     let ven = if user.scope.contains(Scope::WriteVensBl) {
         ven_source.delete(&id, &None).await?
+    } else if user.scope.contains(Scope::WriteVensVen) {
+        ven_source.delete(&id, &Some(user.client_id()?)).await?
     } else {
         return Err(AppError::Forbidden("Missing 'write_vens_bl' scope"));
     };

--- a/openleadr-vtn/src/api/ven.rs
+++ b/openleadr-vtn/src/api/ven.rs
@@ -336,7 +336,7 @@ mod tests {
                 "test-client",
                 Scope::all()
                     .into_iter()
-                    .filter(|s| *s != Scope::WriteVensBl)
+                    .filter(|&s| s != Scope::WriteVensBl && s != Scope::WriteVensVen)
                     .collect(),
             )
             .await;
@@ -346,6 +346,25 @@ mod tests {
                 .await;
 
             assert_eq!(status, StatusCode::FORBIDDEN);
+        }
+
+        #[sqlx::test(fixtures("vens"))]
+        async fn can_delete_own_resource_with_correct_scope(db: PgPool) {
+            let test = ApiTest::new(
+                db.clone(),
+                "test-client",
+                Scope::all()
+                    .into_iter()
+                    .filter(|&s| s != Scope::WriteVensBl)
+                    .collect(),
+            )
+            .await;
+
+            let (status, _) = test
+                .request::<Ven>(Method::DELETE, "/vens/ven-1", Body::empty())
+                .await;
+
+            assert_eq!(status, StatusCode::OK);
         }
     }
 


### PR DESCRIPTION
This is required per the specification, as it is part of the write permissions.