### PR TITLE
Allow both scope and roles claim in JWT token claims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.zed/
 .idea/
 **/target
 oadr*.yaml

--- a/openleadr-vtn/src/api/event.rs
+++ b/openleadr-vtn/src/api/event.rs
@@ -32,9 +32,9 @@ pub async fn get_all(
     User(user): User,
 ) -> AppResponse<Vec<Event>> {
     trace!(?query_params);
-    let events = if user.scope.contains(Scope::ReadAll) {
+    let events = if user.has_scope(Scope::ReadAll) {
         event_source.retrieve_all(&query_params, &None).await?
-    } else if user.scope.contains(Scope::ReadTargets) {
+    } else if user.has_scope(Scope::ReadTargets) {
         event_source
             .retrieve_all(&query_params, &Some(user.client_id()?))
             .await?
@@ -53,9 +53,9 @@ pub async fn get(
     Path(id): Path<EventId>,
     User(user): User,
 ) -> AppResponse<Event> {
-    let event = if user.scope.contains(Scope::ReadAll) {
+    let event = if user.has_scope(Scope::ReadAll) {
         event_source.retrieve(&id, &None).await?
-    } else if user.scope.contains(Scope::ReadTargets) {
+    } else if user.has_scope(Scope::ReadTargets) {
         event_source.retrieve(&id, &Some(user.client_id()?)).await?
     } else {
         return Err(AppError::Forbidden(
@@ -74,7 +74,7 @@ pub async fn add(
     User(user): User,
     ValidatedJson(new_event): ValidatedJson<EventRequest>,
 ) -> Result<(StatusCode, Json<Event>), AppError> {
-    if !user.scope.contains(Scope::WriteEvents) {
+    if !user.has_scope(Scope::WriteEvents) {
         return Err(AppError::Forbidden("Missing 'write_events' scope"));
     }
 
@@ -102,7 +102,7 @@ pub async fn edit(
     User(user): User,
     ValidatedJson(content): ValidatedJson<EventRequest>,
 ) -> AppResponse<Event> {
-    if !user.scope.contains(Scope::WriteEvents) {
+    if !user.has_scope(Scope::WriteEvents) {
         return Err(AppError::Forbidden("Missing 'write_events' scope"));
     }
 
@@ -129,7 +129,7 @@ pub async fn delete(
     Path(id): Path<EventId>,
     User(user): User,
 ) -> AppResponse<Event> {
-    if !user.scope.contains(Scope::WriteEvents) {
+    if !user.has_scope(Scope::WriteEvents) {
         return Err(AppError::Forbidden("Missing 'write_events' scope"));
     }
 

--- a/openleadr-vtn/src/api/program.rs
+++ b/openleadr-vtn/src/api/program.rs
@@ -31,9 +31,9 @@ pub async fn get_all(
 ) -> AppResponse<Vec<Program>> {
     trace!(?query_params);
 
-    let programs = if user.scope.contains(Scope::ReadAll) {
+    let programs = if user.has_scope(Scope::ReadAll) {
         program_source.retrieve_all(&query_params, &None).await?
-    } else if user.scope.contains(Scope::ReadTargets) {
+    } else if user.has_scope(Scope::ReadTargets) {
         program_source
             .retrieve_all(&query_params, &Some(user.client_id()?))
             .await?
@@ -57,9 +57,9 @@ pub async fn get(
     Path(id): Path<ProgramId>,
     User(user): User,
 ) -> AppResponse<Program> {
-    let program = if user.scope.contains(Scope::ReadAll) {
+    let program = if user.has_scope(Scope::ReadAll) {
         program_source.retrieve(&id, &None).await?
-    } else if user.scope.contains(Scope::ReadTargets) {
+    } else if user.has_scope(Scope::ReadTargets) {
         program_source
             .retrieve(&id, &Some(user.client_id()?))
             .await?
@@ -86,7 +86,7 @@ pub async fn add(
     User(user): User,
     ValidatedJson(new_program): ValidatedJson<ProgramRequest>,
 ) -> Result<(StatusCode, Json<Program>), AppError> {
-    if !user.scope.contains(Scope::WritePrograms) {
+    if !user.has_scope(Scope::WritePrograms) {
         return Err(AppError::Forbidden("Missing 'write_programs' scope"));
     }
 
@@ -120,7 +120,7 @@ pub async fn edit(
     User(user): User,
     ValidatedJson(content): ValidatedJson<ProgramRequest>,
 ) -> AppResponse<Program> {
-    if !user.scope.contains(Scope::WritePrograms) {
+    if !user.has_scope(Scope::WritePrograms) {
         return Err(AppError::Forbidden("Missing 'write_programs' scope"));
     }
 
@@ -153,7 +153,7 @@ pub async fn delete(
     Path(id): Path<ProgramId>,
     User(user): User,
 ) -> AppResponse<Program> {
-    if !user.scope.contains(Scope::WritePrograms) {
+    if !user.has_scope(Scope::WritePrograms) {
         return Err(AppError::Forbidden("Missing 'write_programs' scope"));
     }
 

--- a/openleadr-vtn/src/api/report.rs
+++ b/openleadr-vtn/src/api/report.rs
@@ -30,9 +30,9 @@ pub async fn get_all(
     ValidatedQuery(query_params): ValidatedQuery<QueryParams>,
     User(user): User,
 ) -> AppResponse<Vec<Report>> {
-    let reports = if user.scope.contains(Scope::ReadAll) {
+    let reports = if user.has_scope(Scope::ReadAll) {
         report_source.retrieve_all(&query_params, &None).await?
-    } else if user.scope.contains(Scope::ReadVenObjects) {
+    } else if user.has_scope(Scope::ReadVenObjects) {
         report_source
             .retrieve_all(&query_params, &Some(user.client_id()?))
             .await?
@@ -53,9 +53,9 @@ pub async fn get(
     Path(id): Path<ReportId>,
     User(user): User,
 ) -> AppResponse<Report> {
-    let report = if user.scope.contains(Scope::ReadAll) {
+    let report = if user.has_scope(Scope::ReadAll) {
         report_source.retrieve(&id, &None).await?
-    } else if user.scope.contains(Scope::ReadVenObjects) {
+    } else if user.has_scope(Scope::ReadVenObjects) {
         report_source
             .retrieve(&id, &Some(user.client_id()?))
             .await?
@@ -78,7 +78,7 @@ pub async fn add(
     User(user): User,
     ValidatedJson(new_report): ValidatedJson<ReportRequest>,
 ) -> Result<(StatusCode, Json<Report>), AppError> {
-    let report = if user.scope.contains(Scope::WriteReports) {
+    let report = if user.has_scope(Scope::WriteReports) {
         report_source
             .create(new_report, &Some(user.client_id()?))
             .await?
@@ -108,7 +108,7 @@ pub async fn edit(
     User(user): User,
     ValidatedJson(content): ValidatedJson<ReportRequest>,
 ) -> AppResponse<Report> {
-    let report = if user.scope.contains(Scope::WriteReports) {
+    let report = if user.has_scope(Scope::WriteReports) {
         report_source
             .update(&id, content, &Some(user.client_id()?))
             .await?
@@ -142,7 +142,7 @@ pub async fn delete(
     // where a BL client can delete a report.
     // If a BL tried to delete a report, it would either fail by not having the `write_reports` scope
     // or because the BLs client_id does not match the reports client_id.
-    let report = if user.scope.contains(Scope::WriteReports) {
+    let report = if user.has_scope(Scope::WriteReports) {
         report_source.delete(&id, &Some(user.client_id()?)).await?
     } else {
         return Err(AppError::Forbidden("Missing 'write_reports' scope"));

--- a/openleadr-vtn/src/api/resource.rs
+++ b/openleadr-vtn/src/api/resource.rs
@@ -32,9 +32,9 @@ pub async fn get_all(
 ) -> AppResponse<Vec<Resource>> {
     trace!(?query_params);
 
-    let resources = if user.scope.contains(Scope::ReadAll) {
+    let resources = if user.has_scope(Scope::ReadAll) {
         resource_source.retrieve_all(&query_params, &None).await?
-    } else if user.scope.contains(Scope::ReadVenObjects) {
+    } else if user.has_scope(Scope::ReadVenObjects) {
         resource_source
             .retrieve_all(&query_params, &Some(user.client_id()?))
             .await?
@@ -58,9 +58,9 @@ pub async fn get(
     Path(id): Path<ResourceId>,
     User(user): User,
 ) -> AppResponse<Resource> {
-    let resource = if user.scope.contains(Scope::ReadAll) {
+    let resource = if user.has_scope(Scope::ReadAll) {
         resource_source.retrieve(&id, &None).await?
-    } else if user.scope.contains(Scope::ReadVenObjects) {
+    } else if user.has_scope(Scope::ReadVenObjects) {
         resource_source
             .retrieve(&id, &Some(user.client_id()?))
             .await?
@@ -88,14 +88,14 @@ pub async fn add(
     User(user): User,
     ValidatedJson(new_resource): ValidatedJson<ResourceRequest>,
 ) -> Result<(StatusCode, Json<Resource>), AppError> {
-    let resource = if user.scope.contains(Scope::WriteVensBl) {
+    let resource = if user.has_scope(Scope::WriteVensBl) {
         let ResourceRequest::BlResourceRequest(new_resource) = new_resource else {
             return Err(AppError::BadRequest(
                 "Did receive a VEN_RESOURCE_REQUEST, but user is authenticated as a BL client",
             ));
         };
         resource_source.create(new_resource, &None).await?
-    } else if user.scope.contains(Scope::WriteVensVen) {
+    } else if user.has_scope(Scope::WriteVensVen) {
         let ResourceRequest::VenResourceRequest(new_resource) = new_resource else {
             return Err(AppError::BadRequest(
                 "Did receive a BL_RESOURCE_REQUEST, but user is authenticated as a VEN client",
@@ -152,14 +152,14 @@ pub async fn edit(
     User(user): User,
     ValidatedJson(update): ValidatedJson<ResourceRequest>,
 ) -> AppResponse<Resource> {
-    let resource = if user.scope.contains(Scope::WriteVensBl) {
+    let resource = if user.has_scope(Scope::WriteVensBl) {
         let ResourceRequest::BlResourceRequest(update) = update else {
             return Err(AppError::BadRequest(
                 "Did receive a VEN_RESOURCE_REQUEST, but user is authenticated as a BL client",
             ));
         };
         resource_source.update(&id, update, &None).await?
-    } else if user.scope.contains(Scope::WriteVensVen) {
+    } else if user.has_scope(Scope::WriteVensVen) {
         let ResourceRequest::VenResourceRequest(update) = update else {
             return Err(AppError::BadRequest(
                 "Did receive a BL_RESOURCE_REQUEST, but user is authenticated as a VEN client",
@@ -219,9 +219,9 @@ pub async fn delete(
     Path(id): Path<ResourceId>,
     User(user): User,
 ) -> AppResponse<Resource> {
-    let resource = if user.scope.contains(Scope::WriteVensBl) {
+    let resource = if user.has_scope(Scope::WriteVensBl) {
         resource_source.delete(&id, &None).await?
-    } else if user.scope.contains(Scope::WriteVensVen) {
+    } else if user.has_scope(Scope::WriteVensVen) {
         resource_source
             .delete(&id, &Some(user.client_id()?))
             .await?

--- a/openleadr-vtn/src/api/subscription.rs
+++ b/openleadr-vtn/src/api/subscription.rs
@@ -86,11 +86,11 @@ pub async fn get_all(
         return Err(AppError::BadRequest(error));
     }
 
-    let resources = if user.scope.contains(Scope::ReadAll) {
+    let resources = if user.has_scope(Scope::ReadAll) {
         subscription_source
             .retrieve_all(&query_params, &None)
             .await?
-    } else if user.scope.contains(Scope::ReadVenObjects) {
+    } else if user.has_scope(Scope::ReadVenObjects) {
         subscription_source
             .retrieve_all(&query_params, &Some(user.client_id()?))
             .await?
@@ -114,9 +114,9 @@ pub async fn get(
     Path(id): Path<SubscriptionId>,
     User(user): User,
 ) -> AppResponse<Subscription> {
-    let subscription = if user.scope.contains(Scope::ReadAll) {
+    let subscription = if user.has_scope(Scope::ReadAll) {
         subscription_source.retrieve(&id, &None).await?
-    } else if user.scope.contains(Scope::ReadVenObjects) {
+    } else if user.has_scope(Scope::ReadVenObjects) {
         subscription_source
             .retrieve(&id, &Some(user.client_id()?))
             .await?
@@ -144,7 +144,7 @@ pub async fn add(
 ) -> Result<(StatusCode, Json<Subscription>), AppError> {
     let client_id = user.client_id()?;
 
-    let subscription = if user.scope.contains(Scope::WriteSubscriptions) {
+    let subscription = if user.has_scope(Scope::WriteSubscriptions) {
         subscription_source
             .create(new_subscription, &Some(client_id))
             .await?
@@ -176,7 +176,7 @@ pub async fn edit(
     User(user): User,
     ValidatedJson(update): ValidatedJson<SubscriptionRequest>,
 ) -> AppResponse<Subscription> {
-    let subscription = if user.scope.contains(Scope::WriteSubscriptions) {
+    let subscription = if user.has_scope(Scope::WriteSubscriptions) {
         subscription_source
             .update(&id, update, &Some(user.client_id()?))
             .await?
@@ -207,7 +207,7 @@ pub async fn delete(
     Path(id): Path<SubscriptionId>,
     User(user): User,
 ) -> AppResponse<Subscription> {
-    let subscription = if user.scope.contains(Scope::WriteSubscriptions) {
+    let subscription = if user.has_scope(Scope::WriteSubscriptions) {
         subscription_source
             .delete(&id, &Some(user.client_id()?))
             .await?
@@ -308,7 +308,7 @@ pub(crate) async fn notify(
 }
 
 pub(crate) async fn notifier_get(User(user): User) -> Result<Json<NotifiersResponse>, AppError> {
-    if !user.scope.contains(Scope::ReadAll) {
+    if !user.has_scope(Scope::ReadAll) {
         return Err(AppError::Forbidden("Missing 'read_all' scope"));
     }
 
@@ -323,7 +323,7 @@ pub(crate) async fn notifier_websocket_get(
     User(user): User,
     ws: WebSocketUpgrade,
 ) -> Result<Response, AppError> {
-    if !user.scope.contains(Scope::ReadAll) {
+    if !user.has_scope(Scope::ReadAll) {
         return Err(AppError::Forbidden("Missing 'read_all' scope"));
     }
 

--- a/openleadr-vtn/src/api/user.rs
+++ b/openleadr-vtn/src/api/user.rs
@@ -35,7 +35,7 @@ pub async fn get_all(
     State(auth_source): State<Arc<dyn AuthSource>>,
     User(user): User,
 ) -> AppResponse<Vec<UserDetails>> {
-    if !user.scope.contains(Scope::WriteUsers) {
+    if !user.has_scope(Scope::WriteUsers) {
         return Err(AppError::Forbidden("Missing 'write_users' scope"));
     }
 
@@ -50,7 +50,7 @@ pub async fn get(
     Path(id): Path<String>,
     User(user): User,
 ) -> AppResponse<UserDetails> {
-    if !user.scope.contains(Scope::WriteUsers) {
+    if !user.has_scope(Scope::WriteUsers) {
         return Err(AppError::Forbidden("Missing 'write_users' scope"));
     }
 
@@ -64,7 +64,7 @@ pub async fn add_user(
     User(user): User,
     ValidatedJson(new_user): ValidatedJson<NewUser>,
 ) -> Result<(StatusCode, Json<UserDetails>), AppError> {
-    if !user.scope.contains(Scope::WriteUsers) {
+    if !user.has_scope(Scope::WriteUsers) {
         return Err(AppError::Forbidden("Missing 'write_users' scope"));
     }
 
@@ -85,7 +85,7 @@ pub async fn add_credential(
     User(user): User,
     ValidatedJson(new): ValidatedJson<NewCredential>,
 ) -> AppResponse<UserDetails> {
-    if !user.scope.contains(Scope::WriteUsers) {
+    if !user.has_scope(Scope::WriteUsers) {
         return Err(AppError::Forbidden("Missing 'write_users' scope"));
     }
 
@@ -107,7 +107,7 @@ pub async fn edit(
     User(user): User,
     ValidatedJson(modified): ValidatedJson<NewUser>,
 ) -> AppResponse<UserDetails> {
-    if !user.scope.contains(Scope::WriteUsers) {
+    if !user.has_scope(Scope::WriteUsers) {
         return Err(AppError::Forbidden("Missing 'write_users' scope"));
     }
 
@@ -129,7 +129,7 @@ pub async fn delete_user(
     Path(id): Path<String>,
     User(user): User,
 ) -> AppResponse<UserDetails> {
-    if !user.scope.contains(Scope::WriteUsers) {
+    if !user.has_scope(Scope::WriteUsers) {
         return Err(AppError::Forbidden("Missing 'write_users' scope"));
     }
 
@@ -143,7 +143,7 @@ pub async fn delete_credential(
     Path((user_id, client_id)): Path<(String, String)>,
     User(user): User,
 ) -> AppResponse<UserDetails> {
-    if !user.scope.contains(Scope::WriteUsers) {
+    if !user.has_scope(Scope::WriteUsers) {
         return Err(AppError::Forbidden("Missing 'write_users' scope"));
     }
 

--- a/openleadr-vtn/src/api/ven.rs
+++ b/openleadr-vtn/src/api/ven.rs
@@ -31,9 +31,9 @@ pub async fn get_all(
 ) -> AppResponse<Vec<Ven>> {
     trace!(?query_params);
 
-    let vens = if user.scope.contains(Scope::ReadAll) {
+    let vens = if user.has_scope(Scope::ReadAll) {
         ven_source.retrieve_all(&query_params, &None).await?
-    } else if user.scope.contains(Scope::ReadVenObjects) {
+    } else if user.has_scope(Scope::ReadVenObjects) {
         ven_source
             .retrieve_all(&query_params, &Some(user.client_id()?))
             .await?
@@ -53,9 +53,9 @@ pub async fn get(
     Path(id): Path<VenId>,
     User(user): User,
 ) -> AppResponse<Ven> {
-    let ven = if user.scope.contains(Scope::ReadAll) {
+    let ven = if user.has_scope(Scope::ReadAll) {
         ven_source.retrieve(&id, &None).await?
-    } else if user.scope.contains(Scope::ReadVenObjects) {
+    } else if user.has_scope(Scope::ReadVenObjects) {
         ven_source.retrieve(&id, &Some(user.client_id()?)).await?
     } else {
         return Err(AppError::Forbidden(
@@ -75,14 +75,14 @@ pub async fn add(
     User(user): User,
     ValidatedJson(new_ven): ValidatedJson<VenRequest>,
 ) -> Result<(StatusCode, Json<Ven>), AppError> {
-    let ven = if user.scope.contains(Scope::WriteVensBl) {
+    let ven = if user.has_scope(Scope::WriteVensBl) {
         let VenRequest::BlVenRequest(new_ven) = new_ven else {
             return Err(AppError::BadRequest(
                 "Did receive a VEN_VEN_REQUEST, but user is authenticated as a BL client",
             ));
         };
         ven_source.create(new_ven, &None).await?
-    } else if user.scope.contains(Scope::WriteVensVen) {
+    } else if user.has_scope(Scope::WriteVensVen) {
         let VenRequest::VenVenRequest(new_ven) = new_ven else {
             return Err(AppError::BadRequest(
                 "Did receive a BL_VEN_REQUEST, but user is authenticated as a VEN client",
@@ -125,14 +125,14 @@ pub async fn edit(
     User(user): User,
     ValidatedJson(update): ValidatedJson<VenRequest>,
 ) -> AppResponse<Ven> {
-    let ven = if user.scope.contains(Scope::WriteVensBl) {
+    let ven = if user.has_scope(Scope::WriteVensBl) {
         let VenRequest::BlVenRequest(update) = update else {
             return Err(AppError::BadRequest(
                 "Did receive a VEN_VEN_REQUEST, but user is authenticated as a BL client",
             ));
         };
         ven_source.update(&id, update, &None).await?
-    } else if user.scope.contains(Scope::WriteVensVen) {
+    } else if user.has_scope(Scope::WriteVensVen) {
         let VenRequest::VenVenRequest(update) = update else {
             return Err(AppError::BadRequest(
                 "Did receive a BL_VEN_REQUEST, but user is authenticated as a VEN client",
@@ -176,7 +176,7 @@ pub async fn delete(
     Path(id): Path<VenId>,
     User(user): User,
 ) -> AppResponse<Ven> {
-    let ven = if user.scope.contains(Scope::WriteVensBl) {
+    let ven = if user.has_scope(Scope::WriteVensBl) {
         ven_source.delete(&id, &None).await?
     } else {
         return Err(AppError::Forbidden("Missing 'write_vens_bl' scope"));

--- a/openleadr-vtn/src/jwt.rs
+++ b/openleadr-vtn/src/jwt.rs
@@ -319,8 +319,9 @@ impl<'de> Visitor<'de> for ScopesVisitor {
         A: de::SeqAccess<'de>,
     {
         let mut scopes = Vec::new();
-        while let Some(scope) = seq.next_element::<Scope>().transpose() {
-            match scope {
+        // First parse as String and only then attempt to parse as Scope
+        while let Some(scope_str) = seq.next_element::<String>()? {
+            match scope_str.parse::<Scope>() {
                 Ok(scope) => scopes.push(scope),
                 Err(err) => warn!("Ignoring invalid scope: {err}"),
             }
@@ -667,6 +668,57 @@ mod test {
             .await;
         assert_eq!(problem.detail, Some("OAuth2 subject cannot be parsed as OpenADR clientId: identifier contains characters besides [a-zA-Z0-9_-]: This is not a valid client ID".to_string()));
         assert_eq!(status_code, 401);
+    }
+
+    #[test]
+    fn check_both_scopes_and_roles() {
+        let claim = r#"{
+            "sub": "test",
+            "exp": 1,
+            "scope": ["read_targets"],
+            "roles": ["write_reports"]
+        }"#;
+        let claim = serde_json::from_str::<Claims>(claim).unwrap();
+        assert!(claim.has_scope(Scope::ReadTargets));
+        assert!(claim.has_scope(Scope::WriteReports));
+    }
+
+    #[test]
+    fn missing_quote_does_not_timeout() {
+        let missing_quotes_around_scope = r#"{
+            "sub": "test",
+            "exp": 1,
+            "scope": [unquoted_value],
+        }"#;
+        let claim = serde_json::from_str::<Claims>(missing_quotes_around_scope);
+
+        // This is invalid JSON, but should not hang
+        let claim_error = claim.unwrap_err();
+        assert!(claim_error
+            .to_string()
+            .starts_with("expected value at line"));
+    }
+
+    #[test]
+    fn invalid_scope_is_ignored() {
+        let claim = r#"{
+            "sub": "test",
+            "exp": 1,
+            "scope": ["bogus"]
+        }"#;
+        let claim = serde_json::from_str::<Claims>(claim).unwrap();
+        assert_eq!(
+            claim,
+            Claims {
+                sub: "test".to_string(),
+                aud: None,
+                exp: 1,
+                iat: None,
+                nbf: None,
+                scope: crate::jwt::Scopes(Vec::with_capacity(0)),
+                roles: crate::jwt::Scopes(Vec::with_capacity(0)),
+            }
+        );
     }
 
     #[test]

--- a/openleadr-vtn/src/jwt.rs
+++ b/openleadr-vtn/src/jwt.rs
@@ -255,8 +255,10 @@ pub(crate) struct Claims {
     /// Can be a single string or an array of strings in the JWT, always deserialized as Vec.
     #[serde(default, deserialize_with = "string_or_vec::deserialize")]
     aud: Option<Vec<String>>,
-    #[serde(default, alias = "roles")]
+    #[serde(default)]
     pub(crate) scope: Scopes,
+    #[serde(default)]
+    pub(crate) roles: Scopes,
 }
 
 impl Claims {
@@ -266,6 +268,11 @@ impl Claims {
                 "OAuth2 subject cannot be parsed as OpenADR clientId: {err}"
             ))
         })
+    }
+
+    /// Returns true if either the `scope` or `roles` claim contains the given scope.
+    pub(crate) fn has_scope(&self, scope: Scope) -> bool {
+        self.scope.contains(scope) || self.roles.contains(scope)
     }
 }
 
@@ -399,6 +406,7 @@ impl JwtManager {
             nbf: Some(now.timestamp()),
             aud,
             scope: scope.into(),
+            roles: Scopes::default(),
         };
 
         if let Some(encoding_key) = &self.encoding_key {
@@ -684,7 +692,8 @@ mod test {
                 exp: 1,
                 iat: None,
                 nbf: None,
-                scope: crate::jwt::Scopes(Vec::with_capacity(0))
+                scope: crate::jwt::Scopes(Vec::with_capacity(0)),
+                roles: crate::jwt::Scopes(Vec::with_capacity(0)),
             }
         );
         assert_eq!(
@@ -695,7 +704,8 @@ mod test {
                 exp: 2,
                 iat: None,
                 nbf: None,
-                scope: crate::jwt::Scopes(Vec::with_capacity(0))
+                scope: crate::jwt::Scopes(Vec::with_capacity(0)),
+                roles: crate::jwt::Scopes(Vec::with_capacity(0)),
             }
         );
         assert_eq!(
@@ -706,7 +716,8 @@ mod test {
                 exp: 3,
                 iat: None,
                 nbf: None,
-                scope: crate::jwt::Scopes(Vec::with_capacity(0))
+                scope: crate::jwt::Scopes(Vec::with_capacity(0)),
+                roles: crate::jwt::Scopes(Vec::with_capacity(0)),
             }
         );
         assert_eq!(
@@ -717,7 +728,8 @@ mod test {
                 exp: 4,
                 iat: None,
                 nbf: None,
-                scope: crate::jwt::Scopes(Vec::with_capacity(0))
+                scope: crate::jwt::Scopes(Vec::with_capacity(0)),
+                roles: crate::jwt::Scopes(Vec::with_capacity(0)),
             }
         );
     }

--- a/openleadr-vtn/src/jwt.rs
+++ b/openleadr-vtn/src/jwt.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 #[cfg(feature = "internal-oauth")]
-use jsonwebtoken::{encode, Header};
+use jsonwebtoken::{Header, encode};
 
 use crate::api::auth::ResponseOAuthError;
 use openleadr_wire::oauth::{OAuthError, OAuthErrorType};
@@ -12,8 +12,8 @@ use axum::{
     http::request::Parts,
 };
 use axum_extra::{
-    headers::{authorization::Bearer, Authorization},
     TypedHeader,
+    headers::{Authorization, authorization::Bearer},
 };
 #[cfg(feature = "internal-oauth")]
 use jsonwebtoken::EncodingKey;
@@ -24,9 +24,8 @@ use derive_more::AsRef;
 use openleadr_wire::ClientId;
 use reqwest::Url;
 use serde::{
-    de,
+    Deserialize, Deserializer, Serialize, de,
     de::{DeserializeOwned, Visitor},
-    Deserialize, Deserializer, Serialize,
 };
 use std::{fmt, str::FromStr};
 
@@ -95,7 +94,7 @@ where
 /// Deserializes the JWT `aud` claim which can be either a single string or an array of strings.
 /// Always returns `Option<Vec<String>>` internally.
 mod string_or_vec {
-    use serde::{de, Deserializer};
+    use serde::{Deserializer, de};
     use std::fmt;
 
     struct StringOrVecVisitor;
@@ -694,9 +693,11 @@ mod test {
 
         // This is invalid JSON, but should not hang
         let claim_error = claim.unwrap_err();
-        assert!(claim_error
-            .to_string()
-            .starts_with("expected value at line"));
+        assert!(
+            claim_error
+                .to_string()
+                .starts_with("expected value at line")
+        );
     }
 
     #[test]


### PR DESCRIPTION
Previously, the scope claim had a roles alias, which meant that only one or the other could be present in the JWT token claims. This change allows for both the `scope` and `roles` claims to be present in a JWT token and will perform authorization checks taking into account both claims.