### PR TITLE
Ignore unmaintained advisory on transient dependency for now

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -25,3 +25,9 @@ allow = [
 name = "ring"
 expression = "ISC AND MIT AND OpenSSL"
 license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[advisories]
+ignore = [
+    # proc-macro-error2
+    "RUSTSEC-2026-0173",
+]


### PR DESCRIPTION
There are some ongoing efforts at forking this dependency to bring it up to date. Will check back in a week if there is an alternative. Since the dependency had already been stale for a while, it is unlikely to break anything short term and is blocking current progress.