### PR TITLE
401 response includes WWW-Authenticate header

### DIFF
--- a/openleadr-vtn/src/api/user.rs
+++ b/openleadr-vtn/src/api/user.rs
@@ -518,7 +518,10 @@ mod test {
 
         let response = help_login(&mut app, "bl-client", "bl-client").await;
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-        assert_eq!(response.headers().get(header::WWW_AUTHENTICATE).unwrap(),r#"Bearer realm="VTN""#);
+        assert_eq!(
+            response.headers().get(header::WWW_AUTHENTICATE).unwrap(),
+            r#"Bearer realm="VTN""#
+        );
     }
 
     #[sqlx::test(fixtures("users"))]
@@ -535,6 +538,9 @@ mod test {
 
         let response = help_login(&mut app, "bl-client", "bl-client").await;
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
-        assert_eq!(response.headers().get(header::WWW_AUTHENTICATE).unwrap(),r#"Bearer realm="VTN""#);
+        assert_eq!(
+            response.headers().get(header::WWW_AUTHENTICATE).unwrap(),
+            r#"Bearer realm="VTN""#
+        );
     }
 }

--- a/openleadr-vtn/src/api/user.rs
+++ b/openleadr-vtn/src/api/user.rs
@@ -166,7 +166,7 @@ mod test {
         Router,
         body::Body,
         http,
-        http::{Request, Response, StatusCode},
+        http::{Request, Response, StatusCode, header},
     };
     use http_body_util::BodyExt;
     use sqlx::PgPool;
@@ -518,6 +518,7 @@ mod test {
 
         let response = help_login(&mut app, "bl-client", "bl-client").await;
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response.headers().get(header::WWW_AUTHENTICATE).unwrap(),r#"Bearer realm="VTN""#);
     }
 
     #[sqlx::test(fixtures("users"))]
@@ -534,5 +535,6 @@ mod test {
 
         let response = help_login(&mut app, "bl-client", "bl-client").await;
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(response.headers().get(header::WWW_AUTHENTICATE).unwrap(),r#"Bearer realm="VTN""#);
     }
 }

--- a/openleadr-vtn/src/error.rs
+++ b/openleadr-vtn/src/error.rs
@@ -6,6 +6,7 @@ use axum::{
     http::StatusCode,
     response::{IntoResponse, Response},
 };
+use axum::http::{header, HeaderValue};
 use axum_extra::extract::QueryRejection;
 use openleadr_wire::{IdentifierError, problem::Problem};
 #[cfg(feature = "sqlx")]
@@ -362,7 +363,14 @@ impl IntoResponse for AppError {
                 }
             }
         };
+        let mut response = (problem.status, Json(problem)).into_response();
+        if response.status() == StatusCode::UNAUTHORIZED {
+            response.headers_mut().insert(
+                header::WWW_AUTHENTICATE,
+                HeaderValue::from_static(r#"Bearer realm="VTN""#),
+            );
+        }
+        response
 
-        (problem.status, Json(problem)).into_response()
     }
 }

--- a/openleadr-vtn/src/error.rs
+++ b/openleadr-vtn/src/error.rs
@@ -3,10 +3,9 @@ use argon2::password_hash;
 use axum::{
     Json,
     extract::rejection::{FormRejection, JsonRejection},
-    http::StatusCode,
+    http::{HeaderValue, StatusCode, header},
     response::{IntoResponse, Response},
 };
-use axum::http::{header, HeaderValue};
 use axum_extra::extract::QueryRejection;
 use openleadr_wire::{IdentifierError, problem::Problem};
 #[cfg(feature = "sqlx")]
@@ -363,6 +362,7 @@ impl IntoResponse for AppError {
                 }
             }
         };
+
         let mut response = (problem.status, Json(problem)).into_response();
         if response.status() == StatusCode::UNAUTHORIZED {
             response.headers_mut().insert(
@@ -371,6 +371,5 @@ impl IntoResponse for AppError {
             );
         }
         response
-
     }
 }


### PR DESCRIPTION
## Summary                                                                                                                                                                                                  
  * Adds `WWW-Authenticate: Bearer realm="VTN"` header to all 401 responses from `AppError`. 
  * The OAuth token endpoint (`ResponseOAuthError` in `auth.rs`) already returned this header for `InvalidClient`, so this PR closes the gap for bearer token auth failures (invalid/expired JWT, unparseable subject).                                                                                            
   
## Approach                                                                                                                                                                                                 
                                                            
*  Considered restructuring the `AppError::into_response()` match to return response tuples from every arm, but instead went for inserting header post-match, based on the response status code. 
* This keeps the existing match structure untouched, at the cost of inconsistency, with a special step just for the Unauthorized arm
* Very open to other ways of doing this!
                                                                                                                                                                                                                                                                                                                                                                                                                      
## Changes                                                   

  - error.rs: Insert WWW-Authenticate header after response construction when status is 401                                                                                                                
  - user.rs: Add header assertions to delete_credential and delete_user tests