### PR TITLE
Fix incorrect SQL syntax

### DIFF
--- a/.sqlx/query-2af3bfd6cb1487f3393ac0714e2db29d139b3711d24ad508c54aa3e1057f273a.json
+++ b/.sqlx/query-2af3bfd6cb1487f3393ac0714e2db29d139b3711d24ad508c54aa3e1057f273a.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM rg_child_ven_resource WHERE rg_parent_rg_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "2af3bfd6cb1487f3393ac0714e2db29d139b3711d24ad508c54aa3e1057f273a"
+}

--- a/.sqlx/query-6f486a14ccc7aeeba7058a3eb4bf3b08fdcaab67d63abe3eaaf3332612f8697a.json
+++ b/.sqlx/query-6f486a14ccc7aeeba7058a3eb4bf3b08fdcaab67d63abe3eaaf3332612f8697a.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM rg_child_rg WHERE rg_parent_rg_id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "6f486a14ccc7aeeba7058a3eb4bf3b08fdcaab67d63abe3eaaf3332612f8697a"
+}

--- a/.sqlx/query-9459ec146a58dc1fa28833f71e295708da7a7ff5bd7dd4ea2ec90f1e9a4b1622.json
+++ b/.sqlx/query-9459ec146a58dc1fa28833f71e295708da7a7ff5bd7dd4ea2ec90f1e9a4b1622.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT rg_child_ven_resource_id FROM rg_child_ven_resource WHERE rg_parent_rg_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "rg_child_ven_resource_id",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "9459ec146a58dc1fa28833f71e295708da7a7ff5bd7dd4ea2ec90f1e9a4b1622"
+}

--- a/.sqlx/query-aeb7929d700a6d3c399627ad7f063d5c7cf9ace7b62770c3b3052c0b4b13d454.json
+++ b/.sqlx/query-aeb7929d700a6d3c399627ad7f063d5c7cf9ace7b62770c3b3052c0b4b13d454.json
@@ -1,0 +1,22 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT rg_child_rg_id FROM rg_child_rg WHERE rg_parent_rg_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "rg_child_rg_id",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "aeb7929d700a6d3c399627ad7f063d5c7cf9ace7b62770c3b3052c0b4b13d454"
+}

--- a/openleadr-vtn/src/api/resource_group.rs
+++ b/openleadr-vtn/src/api/resource_group.rs
@@ -520,4 +520,51 @@ mod test {
             .await;
         assert_eq!(status, StatusCode::NOT_FOUND);
     }
+
+    #[sqlx::test(fixtures("vens", "resources", "resource_groups"))]
+    async fn put_deletes_resource_group_children(db: PgPool) {
+        let test = ApiTest::new(db.clone(), "test-client", vec![Scope::WriteVensBl]).await;
+
+        let (status, resource_group) = test
+            .request::<ResourceGroup>(
+                Method::PUT,
+                "/resource_groups/resource-group-2",
+                Body::from(
+                    r#"
+                      {
+                        "resourceGroupName":"updated-resource-group",
+                        "targets": ["group-3"],
+                        "objectType": "RESOURCE_GROUP_REQUEST",
+                        "children": []
+                      }"#,
+                ),
+            )
+            .await;
+
+        assert_eq!(status, StatusCode::OK);
+        assert!(resource_group.content.children.is_empty());
+
+        let mut tx = db.begin().await.unwrap();
+
+        let naive_rg_children: Vec<_> = sqlx::query!(
+            r#"SELECT rg_child_rg_id FROM rg_child_rg WHERE rg_parent_rg_id = $1"#,
+            "resource-group-2",
+        )
+        .fetch_all(tx.as_mut())
+        .await
+        .unwrap();
+
+        let naive_ven_children: Vec<_> = sqlx::query!(
+            r#"SELECT rg_child_ven_resource_id FROM rg_child_ven_resource WHERE rg_parent_rg_id = $1"#,
+            "resource-group-2",
+        )
+        .fetch_all(tx.as_mut())
+        .await
+        .unwrap();
+
+        tx.commit().await.unwrap();
+
+        assert!(naive_ven_children.is_empty());
+        assert!(naive_rg_children.is_empty());
+    }
 }

--- a/openleadr-vtn/src/data_source/postgres/resource_group.rs
+++ b/openleadr-vtn/src/data_source/postgres/resource_group.rs
@@ -411,6 +411,20 @@ impl Crud for PgResourceGroupStorage {
         .execute(tx.as_mut())
         .await?;
 
+        sqlx::query!(
+            r#"DELETE FROM rg_child_rg WHERE rg_parent_rg_id = $1"#,
+            id.as_str()
+        )
+        .execute(tx.as_mut())
+        .await?;
+
+        sqlx::query!(
+            r#"DELETE FROM rg_child_ven_resource WHERE rg_parent_rg_id = $1"#,
+            id.as_str()
+        )
+        .execute(tx.as_mut())
+        .await?;
+
         insert_resource_group_children(&mut tx, &mut resource_group, &new.children).await?;
         tx.commit().await?;
 
@@ -447,9 +461,14 @@ impl Crud for PgResourceGroupStorage {
         resource_group.content.children.extend(children);
 
         sqlx::query!(
-            r#"
-            DELETE FROM rg_child_rg rg_child_ven_resource WHERE rg_parent_rg_id = $1
-            "#,
+            r#"DELETE FROM rg_child_rg WHERE rg_parent_rg_id = $1"#,
+            id.as_str()
+        )
+        .execute(tx.as_mut())
+        .await?;
+
+        sqlx::query!(
+            r#"DELETE FROM rg_child_ven_resource WHERE rg_parent_rg_id = $1"#,
             id.as_str()
         )
         .execute(tx.as_mut())


### PR DESCRIPTION
closes #471

The code to delete a child resource from the database contained a syntax error, preventing the deletion of ven resources.

The snippet below aliases rg_child_rg to rg_child_ven_resource instead of deleting from both tables as was intended.
```sql
DELETE FROM rg_child_rg rg_child_ven_resource ...
```