### PR TITLE
Issue 75 improve test coverage

### DIFF
--- a/openleadr-client/src/error.rs
+++ b/openleadr-client/src/error.rs
@@ -48,7 +48,7 @@ impl Error {
     /// `403 Forbidden` HTTP status code.
     pub fn is_forbidden(&self) -> bool {
         match self {
-            Error::Problem(openleadr_wire::problem::Problem { status, ..}) => {
+            Error::Problem(openleadr_wire::problem::Problem { status, .. }) => {
                 *status == StatusCode::FORBIDDEN
             }
             _ => false,

--- a/openleadr-client/src/error.rs
+++ b/openleadr-client/src/error.rs
@@ -34,7 +34,8 @@ impl Error {
         }
     }
 
-    #[allow(missing_docs)]
+    /// Checks if the [`Problem`](openleadr_wire::problem::Problem) response of the VTN is a
+    /// `404 Not Found` HTTP status code.
     pub fn is_not_found(&self) -> bool {
         match self {
             Error::Problem(openleadr_wire::problem::Problem { status, .. }) => {

--- a/openleadr-client/src/error.rs
+++ b/openleadr-client/src/error.rs
@@ -43,6 +43,17 @@ impl Error {
             _ => false,
         }
     }
+
+    /// Checks if the [`Problem`](openleadr_wire::problem::Problem) response of the VTN is a
+    /// `403 Forbidden` HTTP status code.
+    pub fn is_forbidden(&self) -> bool {
+        match self {
+            Error::Problem(openleadr_wire::problem::Problem { status, ..}) => {
+                *status == StatusCode::FORBIDDEN
+            }
+            _ => false,
+        }
+    }
 }
 
 impl From<reqwest::Error> for Error {

--- a/openleadr-client/tests/common/mod.rs
+++ b/openleadr-client/tests/common/mod.rs
@@ -19,7 +19,7 @@ pub enum AuthRole {
 fn default_credentials(auth_role: AuthRole) -> ClientCredentials {
     let (id, secr) = match auth_role {
         AuthRole::Bl => ("bl-client", "bl-client"),
-        AuthRole::Ven => ("ven-client", "ven-client"),
+        AuthRole::Ven => ("ven-client-client-id", "ven-client"),
     };
 
     ClientCredentials::new(id.to_string(), secr.to_string())
@@ -167,4 +167,11 @@ pub async fn setup_program_client<K: ClientKind>(
     };
 
     client.create_program(program_content).await.unwrap()
+}
+
+pub async fn setup_client_with_role<K: ClientKind>(db: PgPool, role: AuthRole) -> Client<K> {
+    let cred = default_credentials(role);
+    let storage = PostgresStorage::new(db).unwrap();
+    let app_state = AppState::new(storage, &VtnConfig::from_env()).await;
+    MockClientRef::new(app_state.into_router()).into_client(Some(cred))
 }

--- a/openleadr-client/tests/common/mod.rs
+++ b/openleadr-client/tests/common/mod.rs
@@ -169,6 +169,7 @@ pub async fn setup_program_client<K: ClientKind>(
     client.create_program(program_content).await.unwrap()
 }
 
+#[allow(unused)]
 pub async fn setup_client_with_role<K: ClientKind>(db: PgPool, role: AuthRole) -> Client<K> {
     let cred = default_credentials(role);
     let storage = PostgresStorage::new(db).unwrap();

--- a/openleadr-client/tests/report.rs
+++ b/openleadr-client/tests/report.rs
@@ -63,7 +63,6 @@ async fn report_crud(db: PgPool) {
         assert!(err.is_forbidden());
     }
 
-
     // Update
     let before = *report.modification_date_time();
     report.content_mut().report_name = Some("renamed".to_string());

--- a/openleadr-client/tests/report.rs
+++ b/openleadr-client/tests/report.rs
@@ -1,0 +1,69 @@
+use openleadr_client::{BusinessLogic, VirtualEndNode};
+use openleadr_wire::{
+    event::{EventInterval, EventType, EventValuesMap},
+    program::ProgramRequest,
+    values_map::Value,
+};
+use sqlx::PgPool;
+
+mod common;
+use common::AuthRole;
+
+fn default_program() -> ProgramRequest {
+    ProgramRequest {
+        program_name: "report-test-program".to_string(),
+        interval_period: None,
+        program_descriptions: None,
+        payload_descriptors: None,
+        attributes: None,
+        targets: vec![],
+    }
+}
+
+#[sqlx::test(fixtures("users"))]
+async fn report_crud(db: PgPool) {
+    let bl = common::setup_client_with_role::<BusinessLogic>(db.clone(), AuthRole::Bl).await;
+    let ven = common::setup_client_with_role::<VirtualEndNode>(db, AuthRole::Ven).await;
+
+    let program = bl.create_program(default_program()).await.unwrap();
+    let intervals = vec![EventInterval {
+        id: 0,
+        interval_period: None,
+        payloads: vec![EventValuesMap {
+            value_type: EventType::Price,
+            values: vec![Value::Number(123.4)],
+        }],
+    }];
+    let event_request = program.new_event(intervals);
+    let bl_event = program.create_event(event_request).await.unwrap();
+
+    // The BL `EventClient` can't create reports (no write_reports). Re-fetch the same event
+    // through the VEN client so the ReportClient is bound to VEN credentials.
+    let event = ven.get_event_by_id(bl_event.id()).await.unwrap();
+
+    // Create
+    let report_request_payload = event.new_report("ven-client".to_string());
+    let mut report = event
+        .create_report(report_request_payload.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(report.content(), &report_request_payload);
+
+    // Get
+    let listed = event.get_report_list(None).await.unwrap();
+    assert_eq!(listed.len(), 1);
+    assert_eq!(listed[0].id(), report.id());
+
+    // Update
+    let before = *report.modification_date_time();
+    report.content_mut().report_name = Some("renamed".to_string());
+    report.update().await.unwrap();
+    assert_eq!(report.content().report_name.as_deref(), Some("renamed"));
+    assert!(report.modification_date_time() > &before); // server bumps the timestamp
+
+    // Delete
+    report.delete().await.unwrap();
+    let after_delete = event.get_report_list(None).await.unwrap();
+    assert!(after_delete.is_empty());
+}

--- a/openleadr-client/tests/report.rs
+++ b/openleadr-client/tests/report.rs
@@ -55,6 +55,15 @@ async fn report_crud(db: PgPool) {
     assert_eq!(listed.len(), 1);
     assert_eq!(listed[0].id(), report.id());
 
+    {
+        let err = bl_event
+            .create_report(bl_event.new_report("bl".to_string()))
+            .await
+            .unwrap_err();
+        assert!(err.is_forbidden());
+    }
+
+
     // Update
     let before = *report.modification_date_time();
     report.content_mut().report_name = Some("renamed".to_string());

--- a/openleadr-vtn/src/api/mod.rs
+++ b/openleadr-vtn/src/api/mod.rs
@@ -108,7 +108,7 @@ pub mod test {
     use axum::{
         Router,
         body::Body,
-        http::{self, Request, StatusCode},
+        http::{self, Request, StatusCode, header},
     };
     use http_body_util::BodyExt;
     use openleadr_wire::problem::Problem;
@@ -312,6 +312,49 @@ pub mod test {
             .request::<Problem>(Method::GET, "/not-existent", Body::empty())
             .await;
         assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    #[sqlx::test]
+    async fn missing_token_is_401_with_www_authenticate(db: PgPool) {
+        let mut test = state(db).await.into_router();
+
+        let response = (&mut test)
+            .oneshot(
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/programs")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let status = response.status();
+        let headers = response.headers();
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(headers[header::WWW_AUTHENTICATE], r#"Bearer realm="VTN""#);
+    }
+
+    #[sqlx::test]
+    async fn invalid_token_is_403_without_www_authenticate(db: PgPool) {
+        let mut test = ApiTest::new(db.clone(), "test-client", vec![]).await;
+
+        let response = (&mut test.router)
+            .oneshot(
+                Request::builder()
+                    .header(header::AUTHORIZATION, "Bearer invalid")
+                    .method(Method::GET)
+                    .uri("/programs")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let status = response.status();
+        let headers = response.headers();
+        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert!(!headers.contains_key(header::WWW_AUTHENTICATE));
     }
 
     #[sqlx::test]

--- a/openleadr-vtn/src/error.rs
+++ b/openleadr-vtn/src/error.rs
@@ -373,3 +373,69 @@ impl IntoResponse for AppError {
         response
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use http_body_util::BodyExt;
+
+    async fn problem_of(err: AppError) -> (Problem, axum::http::HeaderMap) {
+        let response = err.into_response();
+        let headers = response.headers().clone();
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let problem: Problem = serde_json::from_slice(&body)
+            .unwrap_or_else(|e| panic!("{e}: {}", String::from_utf8_lossy(&body)));
+        (problem, headers)
+    }
+
+    // Not circular: each arm of `into_response` writes `title` and `status` as two separate
+    // literals, so this catches a copy-paste mismatch. Delete it if `title` is ever derived from
+    // `status` in one place.
+    fn assert_title_matches_status(problem: &Problem) {
+        assert_eq!(problem.title, Some(problem.status.to_string()))
+    }
+
+    #[tokio::test]
+    async fn wrapped_causes_do_not_reach_the_client() {
+        for err in [
+            #[cfg(feature = "sqlx")]
+            AppError::Sql(sqlx::Error::Protocol("relation users_secret".into())), //passes
+            AppError::Mqtt(paho_mqtt::Error::Failure), //passes
+            AppError::PasswordHashError(password_hash::Error::Password),
+        ] {
+            let source = err.to_string();
+            let debug = format!("{err:?}");
+            let (problem, _) = problem_of(err).await;
+
+            assert_title_matches_status(&problem);
+            assert!(
+                problem.status.is_server_error(),
+                "expected 5xx for {debug}, got {}",
+                problem.status
+            );
+            assert!(!problem.detail.unwrap_or_default().contains(&source))
+        }
+    }
+
+    #[tokio::test]
+    async fn not_found_omits_cause() {
+        let (problem, _) = problem_of(AppError::NotFound).await;
+        assert_eq!(problem.status, StatusCode::NOT_FOUND);
+        assert_title_matches_status(&problem);
+        assert!(problem.detail.is_none());
+    }
+
+    #[tokio::test]
+    async fn unauthorized_carries_www_authenticate() {
+        let (problem, headers) = problem_of(AppError::Auth("bad token".to_string())).await;
+        assert_eq!(problem.status, StatusCode::UNAUTHORIZED);
+        assert_eq!(headers[header::WWW_AUTHENTICATE], r#"Bearer realm="VTN""#)
+    }
+
+    #[tokio::test]
+    async fn forbidden_omits_www_authenticate() {
+        let (problem, headers) = problem_of(AppError::Forbidden("Forbidden")).await;
+        assert_eq!(problem.status, StatusCode::FORBIDDEN);
+        assert!(!headers.contains_key(header::WWW_AUTHENTICATE));
+    }
+}

--- a/openleadr-vtn/src/error.rs
+++ b/openleadr-vtn/src/error.rs
@@ -388,9 +388,8 @@ mod test {
         (problem, headers)
     }
 
-    // Not circular: each arm of `into_response` writes `title` and `status` as two separate
-    // literals, so this catches a copy-paste mismatch. Delete it if `title` is ever derived from
-    // `status` in one place.
+    // Each arm of `into_response` writes `title` and `status` as two separate
+    // literals, so this catches a copy-paste mismatch.
     fn assert_title_matches_status(problem: &Problem) {
         assert_eq!(problem.title, Some(problem.status.to_string()))
     }


### PR DESCRIPTION
## Context
Towards #75, adds:
*  integration tests for the `report` resource and unit tests for the error layer
* one bug fix
* small public API addition that the tests needed.

### Bug fix: VEN test credentials were wrong

`tests/common/mod.rs` used `("ven-client", "ven-client")` for `AuthRole::Ven`, but the seeded client
id in `fixtures/users.sql` is `ven-client-client-id`. Any VEN-authenticated integration test failed
with `AuthProblem(InvalidClient)`, which is probably why there weren't any.

### New public API: `Error::is_forbidden`

`openleadr-client` already has `Error::is_conflict` and `Error::is_not_found`. This adds
`is_forbidden` in the same shape. It's additive, so semver-minor.

Happy to drop it if you'd rather not widen the public surface. The only caller is one assertion in
`tests/report.rs`:

```rust
// with the new method
assert!(err.is_forbidden());

// without it
let Error::Problem(problem) = err else { unreachable!() };
assert_eq!(problem.status, StatusCode::FORBIDDEN);
```

Both forms are already used in the suite — the predicate in `tests/ven.rs`, the destructuring in
`tests/program.rs` and `tests/event.rs` — so just let me know which you'd rather and I'll adjust.


### Tests

`openleadr-client/tests/report.rs` — a CRUD pass over the report resource, driven through the real
client against an in-process VTN, plus a 403 case. It needs two clients on one database, because a BL
client creates the program and event but only a VEN client may write reports. Hence the
`setup_client_with_role` helper.

`openleadr-vtn/src/error.rs` — a test module for `impl IntoResponse for AppError`, covering the parts
that aren't just status mapping:

- the 5xx arms that replace the underlying error with a constant, so SQL text and hash internals
  can't reach a client
- `WWW-Authenticate: Bearer realm="VTN"` being attached to a 401, and not to a 403
- `title` matching its status code

`openleadr-vtn/src/api/mod.rs` — two router-level auth tests. Nothing in the suite sent a rejected
token before, so both of `jwt.rs`'s rejection paths were uncovered:

- no `Authorization` header gives 401 with the challenge header
- `Bearer <invalid>` gives 403 without it

### Deliberately not covered

- The remaining `AppError` arms are plain status mappings, so tests for them would just restate the
  `match`. I left them rather than add tests whose only value is a coverage number. Happy to add them
  if you'd prefer the arms covered.
  
-----
## Separate findings

Some other things I noticed while reading this code. I'll open separate issues unless you'd rather
have PRs. Ordered by what I'd guess matters most

1. An invalid bearer token returns 403. OAuth RFC 6750 §3.1 says `invalid_token` should be 401, and reserves
   403 for `insufficient_scope`. Does OpenADR 3.1 specify something different here?

2. `cargo test -p openleadr-vtn --all-features` doesn't compile. The vtn `mdns` feature doesn't turn
   on `openleadr-client/mdns`, so `tests/mdns_integration_test.rs` enables its imports while the
   client is built without them. Building the whole workspace hides this, which is why CI passes.
   Adding `openleadr-client/mdns` to the feature fixes it.

3. `ForeignKeyConstraintViolated` says one thing and returns another. Its error message is
   "Unprocessable Content" (422) but the response is 409. Clients only ever see the 409, so it's
   confusing to read rather than broken. Which was intended?

4. ~`IntoResponse` builds 20 almost identical `Problem` values, where only `status` and `detail` differ.
   Building it once after the match would cut each arm from around 13 lines to 4, with no change in
   behaviour.~ Crossed out as think this is covered by https://github.com/OpenLEADR/openleadr-rs/issues/56

5. `AppError::Identifier` has no `{0}` in its error message, so `error!("{}", app_err)` logs only
   "Malformed Identifier" and drops the detail. One line to fix.

6. `AppError::NotImplemented` is never constructed anywhere. Safe to delete rather than test, since
   `mod error` is private.