### PR TITLE
refactor(vtn): split AppError into a pure to_problem() + thin axum adapter

### DIFF
--- a/openleadr-vtn/src/error.rs
+++ b/openleadr-vtn/src/error.rs
@@ -132,8 +132,9 @@ fn problem(reference: Uuid, status: StatusCode, detail: Option<String>) -> Probl
     }
 }
 
-impl IntoResponse for AppError {
-    fn into_response(self) -> Response {
+impl AppError {
+    /// Maps this error to an HTTP status and RFC7807 problem body.
+    pub(crate) fn into_problem(self) -> (StatusCode, Problem) {
         let reference = Uuid::new_v4();
 
         let problem = match self {
@@ -249,7 +250,15 @@ impl IntoResponse for AppError {
             }
         };
 
-        let mut response = (problem.status, Json(problem)).into_response();
+        (problem.status, problem)
+    }
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let (status, problem) = self.into_problem();
+
+        let mut response = (status, Json(problem)).into_response();
         if response.status() == StatusCode::UNAUTHORIZED {
             response.headers_mut().insert(
                 header::WWW_AUTHENTICATE,


### PR DESCRIPTION
## Summary

- Splits AppError's axum IntoResponse impl into two concerns: a pure
  pub(crate) fn into_problem(self) -> (StatusCode, Problem) that maps every
  variant to an RFC 7807 problem body, and a thin impl IntoResponse for
  AppError that calls it and builds the axum Response (including the
  WWW-Authenticate header on 401s, preserved exactly as before).
- StatusCode here is http::StatusCode and Problem is a plain
  openleadr_wire::problem::Problem, both already framework-neutral types,
  so this is pure code motion: the match self { ... } body moves
  byte-for-byte from into_response into into_problem, with no arm's logic,
  log level, or message text changed.
- Motivation: today the only way to get a status code and problem body out of
  an AppError is axum's IntoResponse. Separating "what does this error map
  to" from "how does axum render that" means the mapping can be reused by
  any adapter around AppError, not just axum's, keeping the RFC 7807
  semantics in one place instead of duplicated per framework.
- Named into_problem, not to_problem: clippy::wrong_self_convention flags a
  to_* method taking a non-Copy self by value, and into_* is the correct
  naming convention for a method that consumes self.
- into_problem is pub(crate), so this isn't a public API change; nothing
  outside the crate can observe the split.

## Test plan

- [x] cargo test -p openleadr-vtn --features live-db-test,compression-br,compression-gzip,experimental-websockets -- --test-threads=1: 190 passed, 0 failed, 2 ignored (pre-existing, unrelated to this change).
- [x] cargo +nightly fmt --all --check -- --config imports_granularity="Crate"
- [x] cargo clippy -p openleadr-vtn --lib --all-features -- -D warnings
- [x] Verified the 401 WWW-Authenticate header logic survived the split: api::user::test::delete_credential and delete_user assert its exact value and both pass unchanged.
- [x] Verified api::test::unsupported_media_type, api::test::not_found, and api::test::method_not_allowed (each exercising a distinct AppError variant's status/detail mapping) pass unchanged.