### PR TITLE
fix(vtn): include IdentifierError detail in AppError::Identifier's message

### DIFF
--- a/openleadr-vtn/src/error.rs
+++ b/openleadr-vtn/src/error.rs
@@ -54,7 +54,7 @@ pub enum AppError {
     #[cfg(feature = "sqlx")]
     #[error("Json (de)serialization error : {0}")]
     SerdeJsonBadRequest(serde_json::Error),
-    #[error("Malformed Identifier")]
+    #[error("Malformed Identifier: {0}")]
     Identifier(#[from] IdentifierError),
     #[error("Method not allowed")]
     MethodNotAllowed,


### PR DESCRIPTION
## Summary

- Fixes #496: `AppError::Identifier`'s `#[error(...)]` message had no `{0}`,
  so `error!("{}", app_err)` (or any other `Display`/`to_string()` call on
  the `AppError` itself) logged only `"Malformed Identifier"` and dropped
  the underlying `IdentifierError`'s detail.
- One-line fix: `#[error("Malformed Identifier")]` -> `#[error("Malformed Identifier: {0}")]`.

## Test plan

- [x] `cargo check -p openleadr-vtn --features live-db-test,compression-br,compression-gzip,experimental-websockets`
- [x] `cargo +nightly fmt --all --check -- --config imports_granularity="Crate"`
- [x] `cargo clippy -p openleadr-vtn --lib --all-features -- -D warnings`